### PR TITLE
✨ [Feat] 로그인 유저 헤더 UI 

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -42,7 +42,7 @@ const Header = () => {
             />
             <ul
               tabIndex={0}
-              className="dropdown-content menu bg-base-100 rounded-box z-[1] w-[116px] p-2 shadow"
+              className="dropdown-content menu bg-base-100 rounded-box z-[1] w-[120px] p-2 shadow"
             >
               <li
                 className="w-full items-center"

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -48,10 +48,10 @@ const Header = () => {
                 className="w-full items-center"
                 onClick={handleNavigateMypage}
               >
-                <a className="hover:font-bold">마이페이지</a>
+                <a className="text-sm hover:font-bold">마이페이지</a>
               </li>
               <li className="w-full items-center" onClick={handleLogout}>
-                <a className="hover:font-bold flex justify-center w-full">
+                <a className="text-sm hover:font-bold flex justify-center w-full">
                   로그아웃
                 </a>
               </li>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,7 +1,23 @@
 import logo from '../../assets/svg/logo.svg';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { FaBell } from 'react-icons/fa6';
+import { useState } from 'react';
 
 const Header = () => {
+  // TODO: API 연결 후 전역 상태관리
+  const [isLogined, setIsLogined] = useState(true);
+
+  const navigate = useNavigate();
+
+  const handleNavigateMypage = () => {
+    navigate('/mypage/my-info');
+  };
+
+  const handleLogout = () => {
+    setIsLogined(false);
+    navigate('/');
+  };
+
   return (
     <div className="w-full h-[62px] border-b-[1px] border-gray-100 grid grid-cols-3 items-center">
       <div />
@@ -13,19 +29,49 @@ const Header = () => {
           </span>
         </Link>
       </div>
-      {/* buttons */}
-      <div className="flex justify-end gap-3 mr-4">
-        <Link to="/login">
-          <button className="btn btn-sm font-inter font-medium btn-second">
-            Login
-          </button>
-        </Link>
-        <Link to="/join">
-          <button className="btn btn-sm font-inter font-medium btn-second">
-            Join
-          </button>
-        </Link>
-      </div>
+
+      {isLogined ? (
+        <div className="flex justify-end items-center gap-5 mr-6">
+          <FaBell className="scale-150 fill-primary cursor-pointer" />
+          <div className="dropdown dropdown-end dropdown-hover">
+            <img
+              tabIndex={0}
+              src="/image/default_profile_image.webp"
+              alt="profile image"
+              className="w-[30px] h-[30px] object-cover p-[1px] border border-gray-600 rounded-full cursor-pointer"
+            />
+            <ul
+              tabIndex={0}
+              className="dropdown-content menu bg-base-100 rounded-box z-[1] w-[116px] p-2 shadow"
+            >
+              <li
+                className="w-full items-center"
+                onClick={handleNavigateMypage}
+              >
+                <a className="hover:font-bold">마이페이지</a>
+              </li>
+              <li className="w-full items-center" onClick={handleLogout}>
+                <a className="hover:font-bold flex justify-center w-full">
+                  로그아웃
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      ) : (
+        <div className="flex justify-end gap-3 mr-4">
+          <Link to="/login">
+            <button className="btn btn-sm font-inter font-medium btn-second">
+              Login
+            </button>
+          </Link>
+          <Link to="/join">
+            <button className="btn btn-sm font-inter font-medium btn-second">
+              Join
+            </button>
+          </Link>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 📌 관련 이슈
- close #44 

## 📝 변경 사항
### AS-IS
- 비로그인 유저의 헤더만 존재

### TO-BE
- 로그인 상태에 따른 헤더 UI 구현
- 프로필 이미지 호버 & 클릭 시 마이페이지, 로그아웃 할 수 있는 드롭다운 생성


## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷

https://github.com/user-attachments/assets/2664b641-c72c-44c8-9557-f3af79972a08



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?
