### PR TITLE
🎉 [Feat] 참가한 모임 컴포넌트 구현 및 상태 관리 리팩토링

### DIFF
--- a/src/components/MyPage/HostedMeetings.tsx
+++ b/src/components/MyPage/HostedMeetings.tsx
@@ -2,12 +2,15 @@ import { useState } from 'react';
 import PostCard from '../PostCard';
 import { posts } from '../../mocks/posts';
 import { useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import { isActiveState } from '../../states/recoilState';
 
 const HostedMeetings = () => {
   const [filteredPosts, setFilteredPosts] = useState(posts);
+  const isActive = useRecoilValue(isActiveState);
 
   // TODO: User Token으로 서버와 통신해 주최한 모임 받아오기
-  // 현재는 하드코딩위해 목데이터 사용
+  // 현재는 목데이터 사용
   const userId = 'user_113';
 
   useEffect(() => {
@@ -20,7 +23,7 @@ const HostedMeetings = () => {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 gap-6 justify-items-start mt-[26px]">
         {filteredPosts.map((post, index) => (
           <div key={index} className="w-full">
-            <PostCard post={post} isHosted={true} />
+            <PostCard post={post} isHosted={isActive == 'isHosted'} />
           </div>
         ))}
       </div>

--- a/src/components/MyPage/MyMeetings.tsx
+++ b/src/components/MyPage/MyMeetings.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useRecoilState } from 'recoil';
 import HostedMeetings from './HostedMeetings';
 import ParticipatedMeetings from './ParticipatedMeetings';
+import { isActiveState } from '../../states/recoilState';
 
 const MyMeetings = () => {
-  const [isActive, setIsActive] = useState('hosted');
+  const [isActive, setIsActive] = useRecoilState(isActiveState);
 
   return (
     <div className="w-full">
@@ -11,24 +12,26 @@ const MyMeetings = () => {
         <div className="flex h-6 text-16px items-center">
           <span
             className={`text-[16px] cursor-pointer hover:font-bold transition-all ${
-              isActive === 'hosted' && 'font-bold'
+              isActive === 'isHosted' && 'font-bold'
             }`}
-            onClick={() => setIsActive('hosted')}
+            onClick={() => setIsActive('isHosted')}
           >
             주최한 모임
           </span>
           <div className="divider divider-horizontal"></div>
           <span
-            className="text-[16px] cursor-pointer hover:font-bold transition-all"
-            onClick={() => setIsActive('participated')}
+            className={`text-[16px] cursor-pointer hover:font-bold transition-all  ${
+              isActive === 'isParticipated' && 'font-bold'
+            }`}
+            onClick={() => setIsActive('isParticipated')}
           >
-            신청한 모임
+            참가한 모임
           </span>
         </div>
       </div>
       <div className="w-5/6 md:5/6 lg:w-4/5 xl:w-3/4 flex mx-auto justify-center">
-        {isActive === 'hosted' && <HostedMeetings />}
-        {isActive === 'participated' && <ParticipatedMeetings />}
+        {isActive === 'isHosted' && <HostedMeetings />}
+        {isActive === 'isParticipated' && <ParticipatedMeetings />}
       </div>
     </div>
   );

--- a/src/components/MyPage/ParticipatedMeetings.tsx
+++ b/src/components/MyPage/ParticipatedMeetings.tsx
@@ -1,5 +1,39 @@
+import { useState, useEffect } from 'react';
+import PostCard from '../PostCard';
+import { posts } from '../../mocks/posts';
+import { useRecoilValue } from 'recoil';
+import { isActiveState } from '../../states/recoilState';
+
 const ParticipatedMeetings = () => {
-  return <div>ParticipatedMeetings</div>;
+  const [filteredPosts, setFilteredPosts] = useState(posts);
+  const isActive = useRecoilValue(isActiveState);
+
+  // TODO: User Token으로 서버와 통신해 주최한 모임 받아오기
+  // 현재는 목데이터 사용
+  const participatedUserId = 'user_512';
+
+  useEffect(() => {
+    const participatedPost = posts.filter(post => {
+      return post.participatedUserId?.includes(participatedUserId);
+    });
+    setFilteredPosts(participatedPost);
+    console.log(participatedPost);
+  }, []);
+
+  return (
+    <div className="px-16 py-1">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 gap-6 justify-items-start mt-[26px]">
+        {filteredPosts.map((post, index) => (
+          <div key={index} className="w-full">
+            <PostCard
+              post={post}
+              isParticipated={isActive === 'isParticipated'}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 };
 
 export default ParticipatedMeetings;

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -110,6 +110,7 @@ const PostCard: React.FC<PostCardProps> = ({
         post={post}
         isHosted={isHosted}
         isParticipated={isParticipated}
+        status={status}
       />
     </div>
   );

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -3,37 +3,47 @@ import { FaPerson } from 'react-icons/fa6';
 import { useNavigate } from 'react-router-dom';
 import { Post } from '../types/Post';
 import { formatDate } from '../utils/formatDate';
+import { getStatusAndColorByRole } from '../utils/getStatusAndColorByRole';
+import PostCardBtn from './postCardBtn';
 
 interface PostCardProps {
   post: Post;
   isHosted?: boolean;
-  // isParticipated?: boolean;
+  isParticipated?: boolean;
 }
+
 const PostCard: React.FC<PostCardProps> = ({
   post,
   isHosted,
-  // isParticipated,
+  isParticipated,
 }) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(`/post/${post.id}`);
-  };
-
-  const handleAdminBtnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    //+
-    e.stopPropagation();
-    navigate(`/post/view-applicant/${post.id}`);
+    if (!isHosted && !isParticipated) {
+      navigate(`/post/${post.id}`);
+    }
   };
 
   const hasThumbnail = post.thumbnail !== undefined;
+
+  let status, color;
+
+  if (isHosted) {
+    ({ status, color } = getStatusAndColorByRole(post.status, 'isHosted'));
+  } else if (isParticipated) {
+    ({ status, color } = getStatusAndColorByRole(
+      post.participationStatus,
+      'isParticipated'
+    ));
+  }
 
   return (
     <div
       className={`w-full aspect-[300/370] px-4 py-6 border shadow-md 
       transform transition-all duration-300 ease-in-out 
       hover:translate-y-[4px] hover:shadow-lg cursor-pointer space-y-2 bg-white ${
-        isHosted ? 'pb-[70px] min-h-[420px]' : 'min-h-[370px]'
+        isHosted || isParticipated ? 'pb-[70px] min-h-[420px]' : 'min-h-[370px]'
       }
       }`}
       onClick={handleClick}
@@ -50,12 +60,17 @@ const PostCard: React.FC<PostCardProps> = ({
           <h2 className="text-lg font-extrabold truncate">{post.title}</h2>
           {isHosted && (
             <div className="flex gap-1 items-center shrink-0">
+              <span className={`w-2 h-2 rounded-full ${color}`}></span>
+              <p className="font-bold text-sm">{status}</p>
+            </div>
+          )}
+          {isParticipated && (
+            <div className="flex gap-1 items-center shrink-0">
               <span
-                className={`w-2 h-2 rounded-full ${
-                  post.status === '모집 완료' ? 'bg-primary' : 'bg-gray-400'
-                }`}
+                className={`w-2 h-2 rounded-full 
+                  ${color}`}
               ></span>
-              <p className="font-bold text-sm">{post.status}</p>
+              <p className="font-bold text-sm">{status}</p>
             </div>
           )}
         </div>
@@ -91,26 +106,11 @@ const PostCard: React.FC<PostCardProps> = ({
           {post.content}
         </p>
       </div>
-      {isHosted && (
-        <div
-          className={`absolute bottom-0 right-0 px-4 py-6 w-full flex justify-between gap-4`}
-        >
-          <button
-            type="button"
-            onClick={e => handleAdminBtnClick(e)}
-            className="btn btn-second btn-sm font-bold z-100 flex-1"
-          >
-            모집글 보기
-          </button>
-          <button
-            type="button"
-            onClick={e => handleAdminBtnClick(e)}
-            className="btn btn-second btn-sm font-bold z-100 flex-1"
-          >
-            신청자 보기
-          </button>
-        </div>
-      )}
+      <PostCardBtn
+        post={post}
+        isHosted={isHosted}
+        isParticipated={isParticipated}
+      />
     </div>
   );
 };

--- a/src/components/PostCardBtn.tsx
+++ b/src/components/PostCardBtn.tsx
@@ -1,15 +1,18 @@
 import { useNavigate } from 'react-router-dom';
 import { Post } from '../types/Post';
+import { HostStatus, ParticipantStatus } from '../types/Post';
 
 interface PostCardBtnProps {
   post: Post;
   isHosted?: boolean;
   isParticipated?: boolean;
+  status?: HostStatus | ParticipantStatus;
 }
 const PostCardBtn: React.FC<PostCardBtnProps> = ({
   post,
   isHosted,
   isParticipated,
+  status,
 }) => {
   const navigate = useNavigate();
 
@@ -28,23 +31,32 @@ const PostCardBtn: React.FC<PostCardBtnProps> = ({
     // TODO: API 참가한 모임 목록에서 DELETE 요청
   };
 
+  const isAvailableDelete =
+    status === '승인 거부' || status === '모집 취소' || status === '모집 완료';
+
+  const isAvailableViewPost = status === '모집 중..';
+
   return (
     <>
       {isHosted && (
         <div
           className={`absolute bottom-0 right-0 px-4 py-6 w-full flex justify-between gap-4`}
         >
-          <button
-            type="button"
-            onClick={e => handleGoToPostBtnClick(e)}
-            className="btn btn-second btn-sm font-bold z-100 flex-1"
-          >
-            모집글 보기
-          </button>
+          {isAvailableViewPost ? (
+            <button
+              type="button"
+              onClick={e => handleGoToPostBtnClick(e)}
+              className="btn btn-second btn-sm font-bold flex-1"
+            >
+              모집글 보기
+            </button>
+          ) : (
+            <div className="flex-1"></div>
+          )}
           <button
             type="button"
             onClick={e => handleAdminBtnClick(e)}
-            className="btn btn-second btn-sm font-bold z-100 flex-1"
+            className="btn btn-second btn-sm font-bold flex-1"
           >
             신청자 보기
           </button>
@@ -57,17 +69,21 @@ const PostCardBtn: React.FC<PostCardBtnProps> = ({
           <button
             type="button"
             onClick={e => handleGoToPostBtnClick(e)}
-            className="btn btn-second btn-sm font-bold z-100 flex-1"
+            className="btn btn-second btn-sm font-bold flex-1"
           >
             모집글 보기
           </button>
-          <button
-            type="button"
-            onClick={e => handleDeleteBtnClick(e)}
-            className="btn btn-second btn-sm font-bold z-100 flex-1"
-          >
-            삭제
-          </button>
+          {isAvailableDelete ? (
+            <button
+              type="button"
+              onClick={e => handleDeleteBtnClick(e)}
+              className="btn btn-second btn-sm font-bold flex-1"
+            >
+              삭제
+            </button>
+          ) : (
+            <div className="flex-1"></div>
+          )}
         </div>
       )}
     </>

--- a/src/components/PostCardBtn.tsx
+++ b/src/components/PostCardBtn.tsx
@@ -1,0 +1,77 @@
+import { useNavigate } from 'react-router-dom';
+import { Post } from '../types/Post';
+
+interface PostCardBtnProps {
+  post: Post;
+  isHosted?: boolean;
+  isParticipated?: boolean;
+}
+const PostCardBtn: React.FC<PostCardBtnProps> = ({
+  post,
+  isHosted,
+  isParticipated,
+}) => {
+  const navigate = useNavigate();
+
+  const handleGoToPostBtnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    navigate(`/post/${post.id}`);
+  };
+
+  const handleAdminBtnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    navigate(`/post/view-applicant/${post.id}`);
+  };
+
+  const handleDeleteBtnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    // TODO: API 참가한 모임 목록에서 DELETE 요청
+  };
+
+  return (
+    <>
+      {isHosted && (
+        <div
+          className={`absolute bottom-0 right-0 px-4 py-6 w-full flex justify-between gap-4`}
+        >
+          <button
+            type="button"
+            onClick={e => handleGoToPostBtnClick(e)}
+            className="btn btn-second btn-sm font-bold z-100 flex-1"
+          >
+            모집글 보기
+          </button>
+          <button
+            type="button"
+            onClick={e => handleAdminBtnClick(e)}
+            className="btn btn-second btn-sm font-bold z-100 flex-1"
+          >
+            신청자 보기
+          </button>
+        </div>
+      )}
+      {isParticipated && (
+        <div
+          className={`absolute bottom-0 right-0 px-4 py-6 w-full flex justify-between gap-4`}
+        >
+          <button
+            type="button"
+            onClick={e => handleGoToPostBtnClick(e)}
+            className="btn btn-second btn-sm font-bold z-100 flex-1"
+          >
+            모집글 보기
+          </button>
+          <button
+            type="button"
+            onClick={e => handleDeleteBtnClick(e)}
+            className="btn btn-second btn-sm font-bold z-100 flex-1"
+          >
+            삭제
+          </button>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default PostCardBtn;

--- a/src/mocks/posts.ts
+++ b/src/mocks/posts.ts
@@ -13,7 +13,9 @@ export const posts: Post[] = [
       '강남의 숨겨진 한식 맛집을 함께 탐방해요! 강남의 숨겨진 한식 맛집을 함께 탐방해요! 강남의 숨겨진 한식 맛집을 함께 탐방해요!',
     thumbnail: 'image/korean_food.webp',
     hostedUserId: 'user_113',
+    participatedUserId: ['user_512'],
     status: '모집 중..',
+    participationStatus: '승인 대기',
   },
   {
     id: '2',
@@ -26,7 +28,9 @@ export const posts: Post[] = [
     content:
       '마포에서 핫한 디저트 카페를 추천합니다. 마포에서 핫한 디저트 카페를 추천합니다. 마포에서 핫한 디저트 카페를 추천합니다.',
     hostedUserId: 'user_456',
+    participatedUserId: ['user_512'],
     status: '모집 완료',
+    participationStatus: '승인 거부',
   },
   {
     id: '3',
@@ -39,7 +43,9 @@ export const posts: Post[] = [
     content: '종로에서 최고의 초밥을 즐기러 갑시다.',
     thumbnail: 'image/sushi.webp',
     hostedUserId: 'user_789',
+    participatedUserId: ['user_512'],
     status: '모집 완료',
+    participationStatus: '승인 대기',
   },
   {
     id: '4',
@@ -51,7 +57,9 @@ export const posts: Post[] = [
     categories: ['중식'],
     content: '동대문에서 중식 신메뉴를 즐기실 분!',
     hostedUserId: 'user_101',
+    participatedUserId: ['user_512'],
     status: '모집 완료',
+    participationStatus: '승인 대기',
   },
   {
     id: '5',
@@ -64,7 +72,9 @@ export const posts: Post[] = [
     content: '서초구에서 고급 스테이크를 함께 먹어요.',
     thumbnail: 'image/steak.webp',
     hostedUserId: 'user_112',
+    participatedUserId: ['user_512'],
     status: '모집 완료',
+    participationStatus: '승인 대기',
   },
   {
     id: '6',
@@ -76,7 +86,9 @@ export const posts: Post[] = [
     categories: ['디저트', '커피'],
     content: '강동구의 조용한 카페에서 디저트 모임!',
     hostedUserId: 'user_113',
+    participatedUserId: ['user_512'],
     status: '모집 완료',
+    participationStatus: '모집 취소',
   },
   {
     id: '7',
@@ -88,7 +100,9 @@ export const posts: Post[] = [
     categories: ['한식'],
     content: '노원구 비빔밥 맛집 투어 함께해요.',
     hostedUserId: 'user_104',
+    participatedUserId: ['user_512'],
     status: '모집 완료',
+    participationStatus: '승인 완료',
   },
   {
     id: '8',
@@ -100,7 +114,9 @@ export const posts: Post[] = [
     categories: ['일식', '라멘'],
     content: '성북구 라멘 맛집에서 모여요.',
     hostedUserId: 'user_105',
+    participatedUserId: ['user_512'],
     status: '모집 완료',
+    participationStatus: '승인 대기',
   },
   {
     id: '9',
@@ -113,7 +129,9 @@ export const posts: Post[] = [
     content: '송파구에서 중화요리와 함께 즐겨요.',
     thumbnail: 'image/chinese_food.webp',
     hostedUserId: 'user_106',
+    participatedUserId: ['user_512', 'user_514'],
     status: '모집 완료',
+    participationStatus: '승인 대기',
   },
   {
     id: '10',
@@ -125,7 +143,9 @@ export const posts: Post[] = [
     categories: ['양식', '피자', '파스타'],
     content: '은평구에서 피자와 파스타를 먹어요.',
     hostedUserId: 'user_107',
+    participatedUserId: ['user_514'],
     status: '모집 완료',
+    participationStatus: '승인 대기',
   },
   {
     id: '11',
@@ -138,7 +158,9 @@ export const posts: Post[] = [
     content: '광진구의 인기 디저트 맛집에 갑시다.',
     thumbnail: 'image/dessert.webp',
     hostedUserId: 'user_108',
+    participatedUserId: ['user_513', 'user_514'],
     status: '모집 중..',
+    participationStatus: '승인 대기',
   },
   {
     id: '12',
@@ -150,7 +172,9 @@ export const posts: Post[] = [
     categories: ['기타'],
     content: '동작구에서 다양한 음식을 탐방합니다.',
     hostedUserId: 'user_109',
+    participatedUserId: ['user_514'],
     status: '모집 완료',
+    participationStatus: '승인 대기',
   },
   {
     id: '13',
@@ -162,7 +186,9 @@ export const posts: Post[] = [
     categories: ['한식', '소주'],
     content: '강서구의 김치찌개 전문점을 찾아갑니다.',
     hostedUserId: 'user_110',
+    participatedUserId: ['user_512'],
     status: '모집 완료',
+    participationStatus: '모집 완료',
   },
   {
     id: '14',
@@ -175,7 +201,9 @@ export const posts: Post[] = [
     content: '중랑구에서 초밥과 사케를 함께해요.',
     thumbnail: 'image/sushi_party.webp',
     hostedUserId: 'user_111',
+    participatedUserId: ['user_513'],
     status: '모집 완료',
+    participationStatus: '승인 거부',
   },
   {
     id: '15',
@@ -187,7 +215,9 @@ export const posts: Post[] = [
     categories: ['중식', '탕수육', '짜장면'],
     content: '금천구의 중식당에서 탕수육을 나눠요.',
     hostedUserId: 'user_112',
+    participatedUserId: ['user_513'],
     status: '모집 완료',
+    participationStatus: '승인 대기',
   },
   {
     id: '16',
@@ -200,6 +230,8 @@ export const posts: Post[] = [
     content: '양천구 프렌치 레스토랑에서 만나요.',
     thumbnail: 'image/french_food.webp',
     hostedUserId: 'user_113',
+    participatedUserId: ['user_512', 'user_513', 'user_514'],
     status: '모집 중..',
+    participationStatus: '모집 취소',
   },
 ];

--- a/src/states/recoilState.ts
+++ b/src/states/recoilState.ts
@@ -1,5 +1,6 @@
 import { atom } from 'recoil';
 import { User } from '../types/User';
+import { ActiveState } from '../types/Post';
 
 export const isFormInvalidFormState = atom<boolean>({
   key: 'isValidUserFormState',
@@ -34,4 +35,9 @@ export const updatedUserDataState = atom<User>({
     introduction: '',
     profileImage: '',
   },
+});
+
+export const isActiveState = atom<ActiveState>({
+  key: 'isActiveState',
+  default: 'isHosted',
 });

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -9,7 +9,9 @@ export interface Post {
   content: string;
   thumbnail?: string;
   hostedUserId?: string;
-  status: string;
+  participatedUserId?: string[];
+  status: HostStatus;
+  participationStatus: ParticipantStatus;
 }
 
 export type PlaceDetail = {
@@ -26,3 +28,13 @@ export type Place = Pick<
   PlaceDetail,
   'place_name' | 'address_name' | 'x' | 'y'
 >;
+
+export type HostStatus = '모집 중..' | '모집 완료';
+export type ParticipantStatus =
+  | '승인 대기'
+  | '승인 완료'
+  | '승인 거부'
+  | '모집 완료'
+  | '모집 취소';
+
+export type ActiveState = 'isHosted' | 'isParticipated';

--- a/src/utils/getStatusAndColorByRole.ts
+++ b/src/utils/getStatusAndColorByRole.ts
@@ -1,0 +1,38 @@
+import { HostStatus, ParticipantStatus, ActiveState } from '../types/Post';
+
+type StatusWithColor = {
+  status: HostStatus | ParticipantStatus;
+  color: string;
+};
+
+export const getStatusAndColorByRole = (
+  status: HostStatus | ParticipantStatus,
+  isActiveState: ActiveState
+): StatusWithColor => {
+  if (isActiveState === 'isHosted') {
+    if (status === '모집 완료') {
+      return { status: '모집 완료', color: 'bg-primary' };
+    } else {
+      return { status: '모집 중..', color: 'bg-gray-400' };
+    }
+  }
+
+  if (isActiveState === 'isParticipated') {
+    switch (status) {
+      case '승인 대기':
+        return { status: '승인 대기', color: 'bg-gray-400' };
+      case '승인 완료':
+        return { status: '승인 완료', color: 'bg-primary' };
+      case '승인 거부':
+        return { status: '승인 거부', color: 'bg-error' };
+      case '모집 완료':
+        return { status: '모집 완료', color: 'bg-error' };
+      case '모집 취소':
+        return { status: '모집 취소', color: 'bg-error' };
+      default:
+        throw new Error(`알 수 없는 상태: ${status}`);
+    }
+  }
+
+  throw new Error('유효하지 않은 상태 또는 역할입니다.');
+};


### PR DESCRIPTION
## 📌 관련 이슈
- close #46 

## 📝 변경 사항
### AS-IS
- 카드를 누르면 상세 페이지로 이동
- 참가한 모임 컴포넌트의 부재

### TO-BE
- 참가한 모임 컴포넌트 구현
- 현재 활성화 된 역할인 `isActive`상태를 리코일로 정의하여 `isHosted`와 `isParticipated` 값 전역으로 관리
- 해당 값이 있을 경우 카드 눌러도 상세 페이지로 이동 X
- PostCardBtn 컴포넌트 분리
- 상태에 따라 상세페이지 or 관리 페이지 or 삭제할 수 있도록 버튼 구현
- `getStatusAndColorByRole` 함수를 따로 분리하여 상태에 따른 컬러값 할당하여 스타일 유지보수 용이하도록 수정
- 목데이터에 participatedUserId배열과 participationStatus 추가해서 테스트



## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 
<img width="1055" alt="스크린샷 2025-01-04 오전 1 18 06" src="https://github.com/user-attachments/assets/bb727c91-b258-49ef-aee3-28d2322773b6" />
스크린샷
<img width="1028" alt="스크린샷 2025-01-04 오전 1 18 16" src="https://github.com/user-attachments/assets/e3f8697a-2512-4e64-8b70-89376c3c7178" />



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
삭제는 함수만 연결해두었고 API 연동하면서 구현할 예정입니다.
