### PR TITLE
👔 Refactor: 카테고리버튼 읽기전용 버전 추가

### DIFF
--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -4,21 +4,34 @@ const Categories = ({
   selectedCategories,
   toggleCategory,
   size = 'sm',
+  categories = CategoryList,
+  readOnly = false,
 }: {
   selectedCategories: string[];
-  toggleCategory: (category: string) => void;
+  toggleCategory?: (category: string) => void;
   size?: string;
+  categories?: string[];
+  readOnly?: boolean;
 }) => {
+  const filteredCategories = readOnly
+    ? categories.filter(category => CategoryList.includes(category))
+    : CategoryList;
+
   return (
     <div className="flex flex-row gap-x-2">
-      {CategoryList.map(category => (
+      {filteredCategories.map(category => (
         <button
           key={category}
           type="button"
           className={`rounded-full btn btn-${size} ${
             selectedCategories.includes(category) && 'btn-primary'
           }`}
-          onClick={() => toggleCategory(category)}
+          onClick={
+            !readOnly && toggleCategory
+              ? () => toggleCategory(category)
+              : undefined
+          }
+          disabled={readOnly}
         >
           {category}
         </button>

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -4,18 +4,14 @@ const Categories = ({
   selectedCategories,
   toggleCategory,
   size = 'sm',
-  categories = CategoryList,
   readOnly = false,
 }: {
   selectedCategories: string[];
   toggleCategory?: (category: string) => void;
   size?: string;
-  categories?: string[];
   readOnly?: boolean;
 }) => {
-  const filteredCategories = readOnly
-    ? categories.filter(category => CategoryList.includes(category))
-    : CategoryList;
+  const filteredCategories = readOnly ? selectedCategories : CategoryList;
 
   return (
     <div className="flex flex-row gap-x-2">


### PR DESCRIPTION
## 📌 관련 이슈
- close #51 

## 📝 변경 사항
### AS-IS
- 카테고리를 선택하는 버튼들 모아놓은 컴포넌트

### TO-BE
- 조회페이지에서 읽기전용으로 사용하기 위해 수정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
