### PR TITLE
✨ Refactor: Layout 컴포넌트 구현 및 적용

### DIFF
--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -11,38 +11,46 @@ const ChatList: React.FC<ChatListProps> = ({ chats, onChatClick }) => {
       <div className="w-full font-bold text-xl flex items-center justify-center border-b-[1px] border-gray-300 pb-5 pt-1">
         <span className="block">채팅</span>
       </div>
-      <ul className="flex flex-col justify-center gap-4 py-4">
-        {chats.map(chat => (
-          <li
-            key={chat.roomId}
-            className="flex justify-between items-center cursor-pointer hover:translate-x-1 duration-300 ease-in-out"
-            onClick={() => onChatClick(chat)}
-          >
-            <img
-              src={chat.meetingThumbnailUrl}
-              alt="Chatting Room Thumbnail"
-              className="w-10 h-10 rounded-full border-[1px] border-black bg-white p-1 mr-2"
-            />
-            <div className="flex flex-1">
-              <div>
-                <span className="font-bold text-[16px]">
-                  {chat.meetingTitle}
-                </span>
-                <p className="text-sm">{chat.lastMessage}</p>
+      {chats.length > 0 ? (
+        <ul className="flex flex-col justify-center gap-4 py-4">
+          {chats.map(chat => (
+            <li
+              key={chat.roomId}
+              className="flex justify-between items-center cursor-pointer hover:translate-x-1 duration-300 ease-in-out"
+              onClick={() => onChatClick(chat)}
+            >
+              <img
+                src={chat.meetingThumbnailUrl}
+                alt="Chatting Room Thumbnail"
+                className="w-10 h-10 rounded-full border-[1px] border-black bg-white p-1 mr-2"
+              />
+              <div className="flex flex-1">
+                <div>
+                  <span className="font-bold text-[16px]">
+                    {chat.meetingTitle}
+                  </span>
+                  <p className="text-sm">{chat.lastMessage}</p>
+                </div>
               </div>
-            </div>
-            {chat.unreadMessagesCount && (
-              <div className="flex justify-center items-center">
-                <span className="block bg-primary px-2 py-1 rounded-full font-bold text-xs">
-                  {chat.unreadMessagesCount >= 100
-                    ? '99+'
-                    : chat.unreadMessagesCount}
-                </span>
-              </div>
-            )}
-          </li>
-        ))}
-      </ul>
+              {chat.unreadMessagesCount && (
+                <div className="flex justify-center items-center">
+                  <span className="block bg-primary px-2 py-1 rounded-full font-bold text-xs">
+                    {chat.unreadMessagesCount >= 100
+                      ? '99+'
+                      : chat.unreadMessagesCount}
+                  </span>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="w-full h-[400px] flex justify-center items-center font-bold text-sm text-center">
+          현재 참가한 채팅방이 없습니다.
+          <br />
+          모임에 참가해 보세요!
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/Chat/ChatModal.tsx
+++ b/src/components/Chat/ChatModal.tsx
@@ -1,4 +1,4 @@
-// import { chats } from '../../mocks/chats';
+import { chats } from '../../mocks/chats';
 import { Chat } from '../../types/Chat';
 import ChatList from './ChatList';
 import ChatRoom from './ChatRoom';
@@ -42,7 +42,9 @@ const ChatModal = () => {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 animate-fadeIn">
       <div className="bg-white p-6 rounded-[40px] shadow-lg w-80 h-[75vh] animate-displayUp">
-        {isChatListOpen && <ChatList chats={[]} onChatClick={openChatRoom} />}
+        {isChatListOpen && (
+          <ChatList chats={chats} onChatClick={openChatRoom} />
+        )}
 
         {isChatRoomOpen && (
           <ChatRoom

--- a/src/components/Chat/ChatModal.tsx
+++ b/src/components/Chat/ChatModal.tsx
@@ -54,7 +54,7 @@ const ChatModal = () => {
           />
         )}
 
-        {isViewParticipantListOpen && (
+        {selectedChat && isViewParticipantListOpen && (
           <ChatParticipantList
             chat={selectedChat}
             handleBackBtn={openChatRoom}

--- a/src/components/Chat/ChatModal.tsx
+++ b/src/components/Chat/ChatModal.tsx
@@ -1,4 +1,4 @@
-import { chats } from '../../mocks/chats';
+// import { chats } from '../../mocks/chats';
 import { Chat } from '../../types/Chat';
 import ChatList from './ChatList';
 import ChatRoom from './ChatRoom';
@@ -42,9 +42,7 @@ const ChatModal = () => {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 animate-fadeIn">
       <div className="bg-white p-6 rounded-[40px] shadow-lg w-80 h-[75vh] animate-displayUp">
-        {isChatListOpen && (
-          <ChatList chats={chats} onChatClick={openChatRoom} />
-        )}
+        {isChatListOpen && <ChatList chats={[]} onChatClick={openChatRoom} />}
 
         {isChatRoomOpen && (
           <ChatRoom

--- a/src/components/Chat/ChatParticipantList.tsx
+++ b/src/components/Chat/ChatParticipantList.tsx
@@ -5,6 +5,8 @@ import { Chat } from '../../types/Chat';
 import { Link } from 'react-router-dom';
 import ChatAlert from './ChatAlert';
 import { useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { isChatModalOpenState } from '../../states/recoilState';
 
 interface ChatParticipantListProps {
   chat: Chat | null;
@@ -15,6 +17,7 @@ const ChatParticipantList = ({
   chat,
   handleBackBtn,
 }: ChatParticipantListProps) => {
+  const setIsModalOpen = useSetRecoilState(isChatModalOpenState);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
 
   if (!chat) return null;
@@ -45,6 +48,7 @@ const ChatParticipantList = ({
           <Link
             key={index}
             to={`/chat/profile/${chat.roomId}/${participant.id}`}
+            onClick={() => setIsModalOpen(false)}
           >
             <li
               key={index}

--- a/src/components/Chat/ChatParticipantList.tsx
+++ b/src/components/Chat/ChatParticipantList.tsx
@@ -50,10 +50,7 @@ const ChatParticipantList = ({
             to={`/chat/profile/${chat.roomId}/${participant.id}`}
             onClick={() => setIsModalOpen(false)}
           >
-            <li
-              key={index}
-              className="flex gap-2 items-center cursor-pointer hover:translate-x-1 duration-300 ease-in-out"
-            >
+            <li className="flex gap-2 items-center cursor-pointer hover:translate-x-1 duration-300 ease-in-out">
               <img
                 src={participant.profileImageUrl}
                 alt="participant profile image"

--- a/src/components/Chat/ChatParticipantList.tsx
+++ b/src/components/Chat/ChatParticipantList.tsx
@@ -9,7 +9,7 @@ import { useSetRecoilState } from 'recoil';
 import { isChatModalOpenState } from '../../states/recoilState';
 
 interface ChatParticipantListProps {
-  chat: Chat | null;
+  chat: Chat;
   handleBackBtn: (chat: Chat) => void;
 }
 
@@ -19,8 +19,6 @@ const ChatParticipantList = ({
 }: ChatParticipantListProps) => {
   const setIsModalOpen = useSetRecoilState(isChatModalOpenState);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
-
-  if (!chat) return null;
 
   // TODO: chat.roomId로 참여자 목록 조회 API 호출
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from 'react-router-dom';
+import ChatFloatingBtn from '../Chat/ChatFloatingBtn';
+import Header from '../Header/Header';
+
+const Layout = () => {
+  return (
+    <>
+      <Header />
+      <Outlet />
+      <ChatFloatingBtn />
+    </>
+  );
+};
+
+export default Layout;

--- a/src/components/UserProfileBtn.tsx
+++ b/src/components/UserProfileBtn.tsx
@@ -1,11 +1,15 @@
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
-import { isViewParticipantListOpenState } from '../states/recoilState';
+import {
+  isChatModalOpenState,
+  isViewParticipantListOpenState,
+} from '../states/recoilState';
 
 const UserProfileBtn = ({ roomId }: { roomId: number }) => {
   const setIsViewParticipantListOpen = useSetRecoilState(
     isViewParticipantListOpenState
   );
+  const setIsChatModalOpen = useSetRecoilState(isChatModalOpenState);
 
   const location = useLocation();
   const { userId } = useParams();
@@ -29,6 +33,7 @@ const UserProfileBtn = ({ roomId }: { roomId: number }) => {
 
   const handleGoToChatRoom = () => {
     setIsViewParticipantListOpen(true);
+    setIsChatModalOpen(true);
     navigate(-1);
   };
 

--- a/src/pages/CreateProfilePage.tsx
+++ b/src/pages/CreateProfilePage.tsx
@@ -1,10 +1,8 @@
-import Header from '../components/Header/Header';
 import CreateProfile from '../components/Join/CreateProfile';
 
 const CreateProfilePage = () => {
   return (
     <>
-      <Header />
       <CreateProfile />
     </>
   );

--- a/src/pages/JoinPage.tsx
+++ b/src/pages/JoinPage.tsx
@@ -1,10 +1,8 @@
-import Header from '../components/Header/Header';
 import JoinForm from '../components/Join/JoinForm';
 
 const JoinPage = () => {
   return (
     <>
-      <Header />
       <JoinForm />
     </>
   );

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -32,6 +32,7 @@ const ListPage = () => {
     navigate(`/post/${id}`);
   };
 
+  // TODO: 타입스크립트로 하라고 하셔요
   const handleSearch = () => {
     const filtered = filteredPosts.filter(post => {
       const matchesCategory =

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,10 +1,8 @@
-import Header from '../components/Header/Header';
 import LoginForm from '../components/Login/LoginForm';
 
 const LoginPage = () => {
   return (
     <>
-      <Header />
       <LoginForm />
     </>
   );

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,15 +1,11 @@
 import { Outlet } from 'react-router-dom';
 import Nav from '../components/MyPage/Nav';
-import Header from '../components/Header/Header';
-import ChatFloatingBtn from '../components/Chat/ChatFloatingBtn';
 
 const MyPage = () => {
   return (
     <>
-      <Header />
       <Nav />
       <Outlet />
-      <ChatFloatingBtn />
     </>
   );
 };

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -1,10 +1,8 @@
-import Header from '../components/Header/Header';
 import ResetPassword from '../components/Join/ResetPassword';
 
 const ResetPasswordPage = () => {
   return (
     <>
-      <Header />
       <ResetPassword />
     </>
   );

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -1,94 +1,102 @@
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { users } from '../mocks/users';
 import { convertGenderToLabel } from '../utils/convertGenderToLabel';
 import { calculateAge } from '../utils/calculateAge';
 import InfoFormField from '../components/MyPage/InfoFormField';
 import UserProfileBtn from '../components/UserProfileBtn';
+import ChatFloatingBtn from '../components/Chat/ChatFloatingBtn';
 
 const UserProfilePage = () => {
   const { userId, roomId } = useParams();
+  const location = useLocation();
+
+  const isChatUserProfilePage = location.pathname !== '/chat/profile';
 
   // TODO: 유저 프로필 가져오기 API
   const selectedUser = users.find(user => user.userId === userId);
 
   return (
-    <div className="w-full h-screen flex justify-center items-center m-auto">
-      <div className="flex flex-col gap-4 items-center">
-        <img
-          src={
-            selectedUser?.profileImage || '/image/default_profile_image.webp'
-          }
-          alt="Profile"
-          className={`w-[150px] h-[150px] object-cover rounded-full mb-[30px] ${
-            selectedUser?.profileImage &&
-            'bg-white p-[5px] border-gray-600 border-[1px]'
-          }`}
-        />
-        <div className="flex justify-between gap-10">
-          <div className="flex flex-col gap-6">
-            <InfoFormField
-              name="nickname"
-              label="닉네임"
-              type="text"
-              disabled
-              required
-              placeholder={selectedUser?.nickname}
-            />
-            <InfoFormField
-              name="age"
-              label="나이"
-              type="text"
-              placeholder={
-                selectedUser?.birth && calculateAge(selectedUser?.birth)
-              }
-              disabled
-            />
+    <>
+      <div className="w-full h-screen flex justify-center items-center m-auto">
+        <div className="flex flex-col gap-4 items-center">
+          <img
+            src={
+              selectedUser?.profileImage || '/image/default_profile_image.webp'
+            }
+            alt="Profile"
+            className={`w-[150px] h-[150px] object-cover rounded-full mb-[30px] ${
+              selectedUser?.profileImage &&
+              'bg-white p-[5px] border-gray-600 border-[1px]'
+            }`}
+          />
+          <div className="flex justify-between gap-10">
+            <div className="flex flex-col gap-6">
+              <InfoFormField
+                name="nickname"
+                label="닉네임"
+                type="text"
+                disabled
+                required
+                placeholder={selectedUser?.nickname}
+              />
+              <InfoFormField
+                name="age"
+                label="나이"
+                type="text"
+                placeholder={
+                  selectedUser?.birth && calculateAge(selectedUser?.birth)
+                }
+                disabled
+              />
 
-            <div className="w-[320px]">
-              <label className="form-control w-full max-w-xs">
-                <div className="label p-0">
-                  <span className="label-text font-bold text-lg mb-2">
-                    자기소개
-                  </span>
-                </div>
-                <textarea
-                  value={selectedUser?.introduction}
-                  className={
-                    'textarea-custom-modified textarea-bordered h-24 py-4 resize-none font-bold placeholder:font-bold'
-                  }
-                  disabled
-                ></textarea>
-              </label>
+              <div className="w-[320px]">
+                <label className="form-control w-full max-w-xs">
+                  <div className="label p-0">
+                    <span className="label-text font-bold text-lg mb-2">
+                      자기소개
+                    </span>
+                  </div>
+                  <textarea
+                    value={selectedUser?.introduction}
+                    className={
+                      'textarea-custom-modified textarea-bordered h-24 py-4 resize-none font-bold placeholder:font-bold'
+                    }
+                    disabled
+                  ></textarea>
+                </label>
+              </div>
             </div>
-          </div>
 
-          <div className="flex flex-col gap-6">
-            <InfoFormField
-              name="gender"
-              label="성별"
-              type="text"
-              placeholder={
-                selectedUser?.gender &&
-                convertGenderToLabel(selectedUser.gender)
-              }
-              disabled
-            />
+            <div className="flex flex-col gap-6">
+              <InfoFormField
+                name="gender"
+                label="성별"
+                type="text"
+                placeholder={
+                  selectedUser?.gender &&
+                  convertGenderToLabel(selectedUser.gender)
+                }
+                disabled
+              />
 
-            <InfoFormField
-              name="mbti"
-              label="MBTI"
-              type="text"
-              disabled
-              value={selectedUser?.mbti}
-            />
+              <InfoFormField
+                name="mbti"
+                label="MBTI"
+                type="text"
+                disabled
+                value={selectedUser?.mbti}
+              />
 
-            <div className="flex gap-3 flex-1 items-end justify-end">
-              <UserProfileBtn roomId={Number(roomId)} />
+              <div className="flex gap-3 flex-1 items-end justify-end">
+                <UserProfileBtn roomId={Number(roomId)} />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+
+      {isChatUserProfilePage && <ChatFloatingBtn />}
+    </>
   );
 };
 

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -10,7 +10,7 @@ const UserProfilePage = () => {
   const { userId, roomId } = useParams();
   const location = useLocation();
 
-  const isChatUserProfilePage = location.pathname !== '/chat/profile';
+  const isChatUserProfilePage = location.pathname.includes('/chat/profile');
 
   // TODO: 유저 프로필 가져오기 API
   const selectedUser = users.find(user => user.userId === userId);

--- a/src/pages/ViewParticipantPage.tsx
+++ b/src/pages/ViewParticipantPage.tsx
@@ -1,5 +1,4 @@
 import { useParams } from 'react-router-dom';
-import Header from '../components/Header/Header';
 import PostCard from '../components/PostCard';
 import { posts } from '../mocks/posts';
 import ParticipantList from '../components/MyPage/ParticipantList';
@@ -11,7 +10,6 @@ const ViewParticipantPage = () => {
 
   return (
     <>
-      <Header />
       <div className="h-[calc(100vh-62px)] flex justify-center items-center overflow-auto">
         <div className="w-full mt-[300px] flex flex-col justify-center items-center gap-14 md:mt-0 md:gap-20 md:flex-row md:items-start">
           {selectedPost && (

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -13,32 +13,37 @@ import ResetPasswordPage from '../pages/ResetPasswordPage';
 import MyMeetings from '../components/MyPage/MyMeetings';
 import ViewParticipantPage from '../pages/ViewParticipantPage';
 import UserProfilePage from '../pages/UserProfilePage';
+import Layout from '../components/Layout/Layout';
 
 const Router = () => {
   return (
     <Routes>
+      {/* 메인페이지 - 모집글 리스트 */}
       <Route path="/" element={<ListPage />} />
       <Route path="/post/:id" element={<PostDetailPage />} />
       <Route path="/create" element={<CreatePostPage />} />
-      {/* 로그인 & 회원가입 */}
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/join" element={<JoinPage />} />
-      <Route path="/reset-password" element={<ResetPasswordPage />} />
-      <Route path="/create-profile" element={<CreateProfilePage />} />
-      {/* 마이페이지 */}
-      <Route path="/mypage" element={<MyPage />}>
-        <Route path="my-info" element={<MyInfo />} />
-        <Route path="my-meetings" element={<MyMeetings />} />
-        <Route path="change-password" element={<ChangePassword />} />
-        <Route path="account-deletion" element={<AccountDeletion />} />
+      {/* 레이아웃 적용 */}
+      <Route element={<Layout />}>
+        {/* 로그인 & 회원가입 */}
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/join" element={<JoinPage />} />
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
+        <Route path="/create-profile" element={<CreateProfilePage />} />
+        {/* 마이페이지 */}
+        <Route path="/mypage" element={<MyPage />}>
+          <Route path="my-info" element={<MyInfo />} />
+          <Route path="my-meetings" element={<MyMeetings />} />
+          <Route path="change-password" element={<ChangePassword />} />
+          <Route path="account-deletion" element={<AccountDeletion />} />
+        </Route>
+        {/* 주최한 모임 -> 신청자 보기 페이지 */}
+        <Route path="/view-applicant/:id" element={<ViewParticipantPage />} />
+        {/* 주최한 모임 -> 신청자 보기 페이지 -> 신청자 프로필 보기 */}
+        <Route
+          path="/view-applicant/profile/:userId"
+          element={<UserProfilePage />}
+        />
       </Route>
-      {/* 주최한 모임 -> 신청자 보기 페이지 */}
-      <Route path="/view-applicant/:id" element={<ViewParticipantPage />} />
-      {/* 주최한 모임 -> 신청자 보기 페이지 -> 신청자 프로필 보기 */}
-      <Route
-        path="/view-applicant/profile/:userId"
-        element={<UserProfilePage />}
-      />
       {/* 채팅 유저 프로필 보기 */}
       <Route
         path="/chat/profile/:roomId/:userId"


### PR DESCRIPTION
## 📌 관련 이슈
- close #62 

## 📝 변경 사항
### AS-IS
- 공통 Layout 컴포넌트의 부재

### TO-BE
- 헤더와 채팅 버튼이 포함된 레이아웃 컴포넌트 구현
- 메인 페이지와 채팅방에서 들어가는 유저 프로필 페이지 제외하고 아울렛 설정

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
도현님이 작업하신 컴포넌트들 중에서
폴더 구조에서 pages에는 렌더링만 담당하도록 하고 나머지는 컴포넌트로 빼는 작업이 추가로 필요할 것 같습니다.
