### PR TITLE
🛠 [Refactor] JoinPage 수정

### DIFF
--- a/src/components/Join/JoinForm.tsx
+++ b/src/components/Join/JoinForm.tsx
@@ -11,10 +11,11 @@ import {
 } from './validation';
 import { JoinErrorMessages } from '../../types/Errors.ts';
 import { formatPhoneNumber } from '../../utils/formatPhoneNumber.ts';
+import axios, { AxiosError } from 'axios';
 
 type Form = {
   email: string;
-  emailConfirmCode: string;
+  // emailConfirmCode: string;
   password: string;
   passwordConfirm: string;
   nickname: string;
@@ -24,7 +25,7 @@ type Form = {
 const JoinForm = () => {
   const [form, setForm] = useState<Form>({
     email: '',
-    emailConfirmCode: '',
+    // emailConfirmCode: '',
     password: '',
     passwordConfirm: '',
     nickname: '',
@@ -33,7 +34,7 @@ const JoinForm = () => {
 
   const [errors, setErrors] = useState<JoinErrorMessages>({
     emailError: null,
-    emailConfirmCodeError: null,
+    // emailConfirmCodeError: null,
     passwordError: null,
     passwordConfirmError: null,
     nicknameError: null,
@@ -42,24 +43,21 @@ const JoinForm = () => {
 
   // TODO: 이메일 인증 실패, 중복값 검사(이메일, 닉네임, 전화 번호), 서버 통신 오류 에러 처리
   // const [joinError, setJoinError] = useState<string | null>(null);
-  const [isInputDisabled, setIsInputDisabled] = useState(true);
-  const [emailConfirmCodeStatus, setEmailConfirmCodeStatus] = useState<
-    'success' | 'error' | null
-  >(null);
+  // const [isInputDisabled, setIsInputDisabled] = useState(true);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
 
     setForm(prev => ({
       ...prev,
-      [name]: name === 'phoneNumber' ? formatPhoneNumber(value) : value,
+      [name]: name === 'phoneNumber' ? value.replace(/[^0-9]/g, '') : value,
     }));
   };
 
   const clearErrors = () => {
     setErrors({
       emailError: null,
-      emailConfirmCodeError: null,
+      // emailConfirmCodeError: null,
       passwordError: null,
       passwordConfirmError: null,
       nicknameError: null,
@@ -72,7 +70,7 @@ const JoinForm = () => {
       emailError: validateEmail(form.email),
       // TODO: 인증 코드 유효성 검사 서버와 통신하여
       // validateEmailConfirmCode 구현 필요
-      emailConfirmCodeError: null,
+      // emailConfirmCodeError: null,
       passwordError: validatePassword(form.password),
       passwordConfirmError: validatePasswordConfirm(
         form.password,
@@ -81,34 +79,6 @@ const JoinForm = () => {
       nicknameError: validateNickname(form.nickname),
       phoneNumberError: validatePhoneNumber(form.phoneNumber),
     });
-  };
-
-  const handleEmailValidation = async () => {
-    console.log('인증 코드 요청');
-    // TODO: API 통신
-    // test: 버튼 클릭 이벤트 하드 코딩
-    const successResponse = { success: true };
-
-    try {
-      const data = successResponse;
-      // TODO: "인증 코드 발송이 완료되었습니다." 화면에 출력 필요
-      if (data.success) {
-        setIsInputDisabled(false);
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const handleEmailConfirmCodeValidation = () => {
-    // test
-    const validCode = '1234';
-
-    if (form.emailConfirmCode === validCode) {
-      setEmailConfirmCodeStatus('success');
-    } else {
-      setEmailConfirmCodeStatus('error');
-    }
   };
 
   const handleJoinSubmit = (e: React.FormEvent) => {
@@ -127,6 +97,31 @@ const JoinForm = () => {
     form.phoneNumber;
   const isDisabled =
     !isFormValid || Object.values(errors).some(error => error !== null);
+
+  const handleSignupRequest = async () => {
+    try {
+      const response = await axios.post(
+        'http://54.180.112.35:8080/api/v1/users/signup',
+        {
+          email: form.email,
+          password: form.password,
+          nickname: form.nickname,
+          phone: form.phoneNumber,
+        }
+      );
+
+      console.log(response.data);
+    } catch (err: unknown) {
+      console.log(err);
+      if (err instanceof AxiosError) {
+        // 서버에서 응답한 오류 메시지 출력
+        console.log('Error response:', err.response);
+      } else {
+        // 다른 오류 처리
+        console.log('Error:', err);
+      }
+    }
+  };
 
   return (
     <div className="w-full h-screen flex justify-center items-center">
@@ -155,21 +150,7 @@ const JoinForm = () => {
             placeholder="이메일을 입력해주세요."
             required
           />
-          <JoinField
-            name="emailConfirmCode"
-            label="인증 코드"
-            type="text"
-            value={form.emailConfirmCode}
-            onChange={e => {
-              handleChange(e);
-            }}
-            onBlur={handleEmailConfirmCodeValidation}
-            error={errors.emailConfirmCodeError}
-            placeholder="인증 코드를 입력해주세요."
-            required
-            disabled={isInputDisabled}
-            emailConfirmCodeStatus={emailConfirmCodeStatus}
-          />
+
           <JoinField
             name="password"
             label="비밀번호"
@@ -234,7 +215,7 @@ const JoinForm = () => {
             name="phoneNumber"
             label="휴대폰 번호"
             type="tel"
-            value={form.phoneNumber}
+            value={formatPhoneNumber(form.phoneNumber)}
             onChange={e => {
               handleChange(e);
             }}
@@ -253,28 +234,20 @@ const JoinForm = () => {
           {/* {joinError && <p className="w-[538px] mb-2 font-bold text-[12px] text-error">{joinError}</p>} */}
 
           <div className="w-full flex justify-center items-center">
-            <Link to="/create-profile">
+            <Link to="/verify-email-code">
               <button
                 type="submit"
                 disabled={isDisabled}
                 className={`btn mt-5 font-bold text-sm ${
                   isDisabled ? 'btn-disabled' : 'btn-primary'
                 }`}
+                onClick={handleSignupRequest}
               >
                 다음 단계로 넘어가기
               </button>
             </Link>
           </div>
         </form>
-
-        <button
-          type="button"
-          // TODO:
-          onClick={handleEmailValidation}
-          className="mt-7 btn btn-primary font-bold text-sm"
-        >
-          이메일 인증
-        </button>
       </div>
     </div>
   );

--- a/src/components/Join/VerifyEmailCode.tsx
+++ b/src/components/Join/VerifyEmailCode.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import JoinField from './JoinField';
 
 const VerifyEmailCode = () => {
@@ -12,22 +12,27 @@ const VerifyEmailCode = () => {
   const navigate = useNavigate();
 
   const handleEmailConfirmCodeValidation = async () => {
-    // TODO: API 통신
-    // 'http://54.180.112.35:8080/api/v1/users/signup/verify'
     try {
       const response = await axios.post(
-        'http://54.180.112.35:8080/api/v1/users/signup',
+        'http://54.180.112.35:8080/api/v1/users/signup/verify',
         {
-          code: emailConfirmCode,
+          params: {
+            code: emailConfirmCode,
+          },
         }
       );
 
       console.log(response.data);
 
       navigate('/create-profile');
-    } catch (error) {
-      console.error(error);
-      setEmailConfirmCodeError('인증 코드가 다릅니다. 다시 확인해 주세요');
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        if (err.response && err.response.status === 400) {
+          setEmailConfirmCodeError(err.response.data.message);
+        } else {
+          setEmailConfirmCodeError('서버와의 연결에 문제가 발생했습니다.');
+        }
+      }
     }
   };
 

--- a/src/components/Join/VerifyEmailCode.tsx
+++ b/src/components/Join/VerifyEmailCode.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import JoinField from './JoinField';
+
+const VerifyEmailCode = () => {
+  const [emailConfirmCode, setEmailConfirmCode] = useState<string>('');
+  const [emailConfirmCodeError, setEmailConfirmCodeError] = useState<
+    string | null
+  >(null);
+  const [emailConfirmCodeStatus, setEmailConfirmCodeStatus] = useState<
+    'success' | 'error' | null
+  >(null);
+
+  const handleEmailValidation = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    console.log('인증 코드 요청');
+    // TODO: API 통신
+    // 'http://54.180.112.35:8080/api/v1/users/signup/verify'
+    // test: 버튼 클릭 이벤트 하드 코딩
+    const successResponse = { success: true };
+
+    try {
+      console.log(successResponse);
+    } catch (error) {
+      console.error(error);
+      setEmailConfirmCodeError(emailConfirmCodeStatus);
+    }
+  };
+
+  const handleEmailConfirmCodeValidation = () => {
+    // test
+    const validCode = '1234';
+
+    if (emailConfirmCode === validCode) {
+      setEmailConfirmCodeStatus('success');
+    } else {
+      setEmailConfirmCodeStatus('error');
+    }
+  };
+
+  return (
+    <div className="w-full h-screen flex justify-center items-center">
+      <div className="max-w-[538px] flex gap-x-6">
+        <form
+          className="w-[320px] flex flex-col gap-4"
+          onSubmit={handleEmailValidation}
+        >
+          <JoinField
+            name="emailConfirmCode"
+            label="인증 코드"
+            type="text"
+            value={emailConfirmCode}
+            onChange={e => {
+              setEmailConfirmCode(e.target.value);
+            }}
+            onBlur={handleEmailConfirmCodeValidation}
+            error={emailConfirmCodeError}
+            placeholder="인증 코드를 입력해주세요."
+            required
+            emailConfirmCodeStatus={emailConfirmCodeStatus}
+          />
+          <Link to={'/create-profile'}>
+            <button
+              type="button"
+              className="mt-7 btn btn-primary font-bold text-sm"
+            >
+              이메일 인증
+            </button>
+          </Link>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default VerifyEmailCode;

--- a/src/components/Join/VerifyEmailCode.tsx
+++ b/src/components/Join/VerifyEmailCode.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import JoinField from './JoinField';
 
 const VerifyEmailCode = () => {
@@ -7,45 +8,33 @@ const VerifyEmailCode = () => {
   const [emailConfirmCodeError, setEmailConfirmCodeError] = useState<
     string | null
   >(null);
-  const [emailConfirmCodeStatus, setEmailConfirmCodeStatus] = useState<
-    'success' | 'error' | null
-  >(null);
 
-  const handleEmailValidation = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const navigate = useNavigate();
 
-    console.log('인증 코드 요청');
+  const handleEmailConfirmCodeValidation = async () => {
     // TODO: API 통신
     // 'http://54.180.112.35:8080/api/v1/users/signup/verify'
-    // test: 버튼 클릭 이벤트 하드 코딩
-    const successResponse = { success: true };
-
     try {
-      console.log(successResponse);
+      const response = await axios.post(
+        'http://54.180.112.35:8080/api/v1/users/signup',
+        {
+          code: emailConfirmCode,
+        }
+      );
+
+      console.log(response.data);
+
+      navigate('/create-profile');
     } catch (error) {
       console.error(error);
-      setEmailConfirmCodeError(emailConfirmCodeStatus);
-    }
-  };
-
-  const handleEmailConfirmCodeValidation = () => {
-    // test
-    const validCode = '1234';
-
-    if (emailConfirmCode === validCode) {
-      setEmailConfirmCodeStatus('success');
-    } else {
-      setEmailConfirmCodeStatus('error');
+      setEmailConfirmCodeError('인증 코드가 다릅니다. 다시 확인해 주세요');
     }
   };
 
   return (
     <div className="w-full h-screen flex justify-center items-center">
       <div className="max-w-[538px] flex gap-x-6">
-        <form
-          className="w-[320px] flex flex-col gap-4"
-          onSubmit={handleEmailValidation}
-        >
+        <div className="w-[320px] flex flex-col gap-4">
           <JoinField
             name="emailConfirmCode"
             label="인증 코드"
@@ -58,17 +47,16 @@ const VerifyEmailCode = () => {
             error={emailConfirmCodeError}
             placeholder="인증 코드를 입력해주세요."
             required
-            emailConfirmCodeStatus={emailConfirmCodeStatus}
           />
-          <Link to={'/create-profile'}>
-            <button
-              type="button"
-              className="mt-7 btn btn-primary font-bold text-sm"
-            >
-              이메일 인증
-            </button>
-          </Link>
-        </form>
+
+          <button
+            type="button"
+            className="mt-7 btn btn-primary font-bold text-sm"
+            onClick={handleEmailConfirmCodeValidation}
+          >
+            이메일 인증
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/VerifyEmailCodePage.tsx
+++ b/src/pages/VerifyEmailCodePage.tsx
@@ -1,0 +1,7 @@
+import VerifyEmailCode from '../components/Join/VerifyEmailCode';
+
+const VerifyEmailCodePage = () => {
+  return <VerifyEmailCode />;
+};
+
+export default VerifyEmailCodePage;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -14,6 +14,7 @@ import MyMeetings from '../components/MyPage/MyMeetings';
 import ViewParticipantPage from '../pages/ViewParticipantPage';
 import UserProfilePage from '../pages/UserProfilePage';
 import Layout from '../components/Layout/Layout';
+import VerifyEmailCode from '../components/Join/VerifyEmailCode';
 
 const Router = () => {
   return (
@@ -26,8 +27,9 @@ const Router = () => {
         {/* 로그인 & 회원가입 */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/join" element={<JoinPage />} />
-        <Route path="/reset-password" element={<ResetPasswordPage />} />
+        <Route path="/verify-email-code" element={<VerifyEmailCode />} />
         <Route path="/create-profile" element={<CreateProfilePage />} />
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
         {/* 마이페이지 */}
         <Route path="/mypage" element={<MyPage />}>
           <Route path="my-info" element={<MyInfo />} />

--- a/src/types/Errors.ts
+++ b/src/types/Errors.ts
@@ -1,6 +1,5 @@
 export type JoinErrorMessages = {
   emailError: string | null;
-  emailConfirmCodeError: string | null;
   passwordError: string | null;
   passwordConfirmError: string | null;
   nicknameError: string | null;


### PR DESCRIPTION
## 📌 관련 이슈
- close #76 

## 📝 변경 사항
### AS-IS
- 회원가입 페이지에서 이메일 인증 버튼을 통해 인증 메일 발송 -> 회원가입 폼 작성 완료 -> 회원가입 API 호출
- API를 통해 이메일 인증 링크 발송

### TO-BE
- 회원가입 페이지와 인증 코드 확인 페이지 분리
- 회원가입 API 호출 -> 이메일로 인증 코드 발송 -> 인증 코드 확인 API 호출 -> 다음 단계로 진행
- 이메일 인증 "링크" 발송에서이메일 인증 "코드" 발송으로 수정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="538" alt="스크린샷 2025-01-15 오후 10 22 24" src="https://github.com/user-attachments/assets/48cf00e1-5d58-442f-b32e-069a92ba27df" />
<img width="426" alt="스크린샷 2025-01-15 오후 10 21 45" src="https://github.com/user-attachments/assets/9c830b7b-2948-4a4a-b199-7cfff513fe33" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
