### PR TITLE
✨ [Feat] 로그아웃 구현

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -18,16 +18,16 @@ const Header = () => {
   const handleLogout = async () => {
     try {
       if (userLoginType === 'emailUser') {
-        const response = await axios.post(
-          '/api/v1/users/logout',
-          {},
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-            },
-          }
-        );
-        console.log('로그아웃 성공:', response.data);
+        const response = await axios.delete('/api/v1/users/logout', {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        console.log(response.data);
+        alert(response.data.message);
+
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('loginUserType');
 
         navigate('/');
       } else if (userLoginType === 'kakaoUser') {
@@ -36,7 +36,11 @@ const Header = () => {
             Authorization: `Bearer ${accessToken}`,
           },
         });
-        console.log('로그아웃 성공:', response.data);
+        console.log(response.data);
+        alert(response.data.message);
+
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('loginUserType');
 
         navigate('/');
       }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,10 +4,13 @@ import { Link, useNavigate } from 'react-router-dom';
 import logo from '../../assets/svg/logo.svg';
 import { notifications } from '../../mocks/notifications';
 import { Notification } from '../../types/Notification';
+import { useRecoilState } from 'recoil';
+import { accessTokenState, userLoginTypeState } from '../../states/recoilState';
+import axios from 'axios';
 
 const Header = () => {
-  // TODO: API 연결 후 전역 상태관리
-  const [isLogined, setIsLogined] = useState(true);
+  const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
+  const [userLoginType, setUserLoginType] = useRecoilState(userLoginTypeState);
 
   const navigate = useNavigate();
 
@@ -15,9 +18,38 @@ const Header = () => {
     navigate('/mypage/my-info');
   };
 
-  const handleLogout = () => {
-    setIsLogined(false);
-    navigate('/');
+  const handleLogout = async () => {
+    try {
+      if (userLoginType === 'emailUser') {
+        const response = await axios.post(
+          '/api/v1/users/logout',
+          {},
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        );
+        console.log('로그아웃 성공:', response.data);
+
+        setAccessToken(null);
+        setUserLoginType(null);
+        navigate('/');
+      } else if (userLoginType === 'kakaoUser') {
+        const response = await axios.delete('/api/v1/kakao/logout', {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        console.log('로그아웃 성공:', response.data);
+
+        setAccessToken(null);
+        setUserLoginType(null);
+        navigate('/');
+      }
+    } catch (err) {
+      console.error('로그아웃 실패:', err);
+    }
   };
 
   // TODO : 서버데이터 사용
@@ -46,7 +78,7 @@ const Header = () => {
         </Link>
       </div>
 
-      {isLogined ? (
+      {accessToken ? (
         <div className="flex justify-end items-center gap-5 mr-6">
           <div
             tabIndex={0}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -88,8 +88,8 @@ const Header = () => {
             <div className="relative menu dropdown-content">
               <ul className="absolute -right-10 bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
                 {hasNotification ? (
-                  data.map(notification => (
-                    <li className="group">
+                  data.map((notification, index) => (
+                    <li className="group" key={index}>
                       <a className="text-xs group-hover:font-bold">
                         {notification.content}
                         <button

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,15 +4,12 @@ import { Link, useNavigate } from 'react-router-dom';
 import logo from '../../assets/svg/logo.svg';
 import { notifications } from '../../mocks/notifications';
 import { Notification } from '../../types/Notification';
-import { useRecoilState } from 'recoil';
-import { accessTokenState, userLoginTypeState } from '../../states/recoilState';
 import axios from 'axios';
 
 const Header = () => {
-  const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
-  const [userLoginType, setUserLoginType] = useRecoilState(userLoginTypeState);
-
   const navigate = useNavigate();
+  const userLoginType = localStorage.getItem('loginUserType');
+  const accessToken = localStorage.getItem('accessToken');
 
   const handleNavigateMypage = () => {
     navigate('/mypage/my-info');
@@ -32,8 +29,6 @@ const Header = () => {
         );
         console.log('로그아웃 성공:', response.data);
 
-        setAccessToken(null);
-        setUserLoginType(null);
         navigate('/');
       } else if (userLoginType === 'kakaoUser') {
         const response = await axios.delete('/api/v1/kakao/logout', {
@@ -43,8 +38,6 @@ const Header = () => {
         });
         console.log('로그아웃 성공:', response.data);
 
-        setAccessToken(null);
-        setUserLoginType(null);
         navigate('/');
       }
     } catch (err) {

--- a/src/components/Join/VerifyEmailCode.tsx
+++ b/src/components/Join/VerifyEmailCode.tsx
@@ -46,7 +46,6 @@ const VerifyEmailCode = () => {
             onChange={e => {
               setEmailConfirmCode(e.target.value);
             }}
-            onBlur={handleEmailConfirmCodeValidation}
             error={emailConfirmCodeError}
             placeholder="인증 코드를 입력해주세요."
             required

--- a/src/components/Login/KakaoLogin.tsx
+++ b/src/components/Login/KakaoLogin.tsx
@@ -2,11 +2,12 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios, { AxiosError } from 'axios';
 import { useSetRecoilState } from 'recoil';
-import { accessTokenState } from '../../states/recoilState';
+import { accessTokenState, userLoginTypeState } from '../../states/recoilState';
 
 const KakaoLogin = () => {
   const navigate = useNavigate();
   const setAccessToken = useSetRecoilState(accessTokenState);
+  const setUserLoginType = useSetRecoilState(userLoginTypeState);
 
   useEffect(() => {
     const code = new URL(window.location.href).searchParams.get('code');
@@ -18,6 +19,7 @@ const KakaoLogin = () => {
         });
 
         setAccessToken(response.data.accessToken);
+        setUserLoginType('kakaoUser');
 
         navigate('/');
       } catch (err) {

--- a/src/components/Login/KakaoLogin.tsx
+++ b/src/components/Login/KakaoLogin.tsx
@@ -21,6 +21,7 @@ const KakaoLogin = () => {
         setAccessToken(response.data.accessToken);
         setUserLoginType('kakaoUser');
 
+        console.log(response.data.accessToken);
         navigate('/');
       } catch (err) {
         if (err instanceof AxiosError) {

--- a/src/components/Login/KakaoLogin.tsx
+++ b/src/components/Login/KakaoLogin.tsx
@@ -1,13 +1,9 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios, { AxiosError } from 'axios';
-import { useSetRecoilState } from 'recoil';
-import { accessTokenState, userLoginTypeState } from '../../states/recoilState';
 
 const KakaoLogin = () => {
   const navigate = useNavigate();
-  const setAccessToken = useSetRecoilState(accessTokenState);
-  const setUserLoginType = useSetRecoilState(userLoginTypeState);
 
   useEffect(() => {
     const code = new URL(window.location.href).searchParams.get('code');
@@ -18,10 +14,9 @@ const KakaoLogin = () => {
           code: code,
         });
 
-        setAccessToken(response.data.accessToken);
-        setUserLoginType('kakaoUser');
+        localStorage.setItem('accessToken', response.data.accessToken);
+        localStorage.setItem('loginUserType', 'kakaoUser');
 
-        console.log(response.data.accessToken);
         navigate('/');
       } catch (err) {
         if (err instanceof AxiosError) {

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -3,15 +3,11 @@ import { RiKakaoTalkFill } from 'react-icons/ri';
 import Input from '../Input';
 import axios, { AxiosError } from 'axios';
 import { useState } from 'react';
-import { useSetRecoilState } from 'recoil';
-import { accessTokenState, userLoginTypeState } from '../../states/recoilState';
 
 const LoginForm = () => {
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [loginError, setLoginError] = useState<string | null>(null);
-  const setAccessToken = useSetRecoilState(accessTokenState);
-  const setUserLoginType = useSetRecoilState(userLoginTypeState);
 
   const navigate = useNavigate();
 
@@ -25,11 +21,10 @@ const LoginForm = () => {
       });
 
       if (response.data && response.data.accessToken) {
-        setAccessToken(response.data.accessToken);
-        setUserLoginType('emailUser');
+        localStorage.setItem('accessToken', response.data.accessToken);
+        localStorage.setItem('loginUserType', 'emailUser');
       }
 
-      console.log(response.data.accessToken);
       navigate('/');
     } catch (err) {
       if (err instanceof AxiosError) {

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -29,6 +29,7 @@ const LoginForm = () => {
         setUserLoginType('emailUser');
       }
 
+      console.log(response.data.accessToken);
       navigate('/');
     } catch (err) {
       if (err instanceof AxiosError) {

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -4,13 +4,14 @@ import Input from '../Input';
 import axios, { AxiosError } from 'axios';
 import { useState } from 'react';
 import { useSetRecoilState } from 'recoil';
-import { accessTokenState } from '../../states/recoilState';
+import { accessTokenState, userLoginTypeState } from '../../states/recoilState';
 
 const LoginForm = () => {
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [loginError, setLoginError] = useState<string | null>(null);
   const setAccessToken = useSetRecoilState(accessTokenState);
+  const setUserLoginType = useSetRecoilState(userLoginTypeState);
 
   const navigate = useNavigate();
 
@@ -25,6 +26,7 @@ const LoginForm = () => {
 
       if (response.data && response.data.accessToken) {
         setAccessToken(response.data.accessToken);
+        setUserLoginType('emailUser');
       }
 
       navigate('/');

--- a/src/states/recoilState.ts
+++ b/src/states/recoilState.ts
@@ -1,8 +1,20 @@
 import { atom } from 'recoil';
-import { User } from '../types/User';
+import { User, UserLoginType } from '../types/User';
 import { ActiveState } from '../types/Post';
 import { Chat } from '../types/Chat';
 
+// 로그인
+export const accessTokenState = atom<string | null>({
+  key: 'accessTokenState',
+  default: null,
+});
+
+export const userLoginTypeState = atom<UserLoginType>({
+  key: 'userLoginTypeState',
+  default: null,
+});
+
+// 마이페이지 & 유저
 export const isFormInvalidFormState = atom<boolean>({
   key: 'isValidUserFormState',
   default: false,
@@ -47,6 +59,7 @@ export const isActiveState = atom<ActiveState>({
   default: 'isHosted',
 });
 
+// 채팅
 export const isChatModalOpenState = atom<boolean>({
   key: 'isChatModalOpenState',
   default: false,
@@ -69,10 +82,5 @@ export const isViewParticipantListOpenState = atom<boolean>({
 
 export const selectedChatState = atom<Chat | null>({
   key: 'selectedChatState',
-  default: null,
-});
-
-export const accessTokenState = atom<string | null>({
-  key: 'accessTokenState',
   default: null,
 });

--- a/src/states/recoilState.ts
+++ b/src/states/recoilState.ts
@@ -1,18 +1,7 @@
 import { atom } from 'recoil';
-import { User, UserLoginType } from '../types/User';
+import { User } from '../types/User';
 import { ActiveState } from '../types/Post';
 import { Chat } from '../types/Chat';
-
-// 로그인
-export const accessTokenState = atom<string | null>({
-  key: 'accessTokenState',
-  default: null,
-});
-
-export const userLoginTypeState = atom<UserLoginType>({
-  key: 'userLoginTypeState',
-  default: null,
-});
 
 // 마이페이지 & 유저
 export const isFormInvalidFormState = atom<boolean>({

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -11,3 +11,5 @@ export interface User {
   userId: string;
   status: string;
 }
+
+export type UserLoginType = 'emailUser' | 'kakaoUser' | null;

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -11,5 +11,3 @@ export interface User {
   userId: string;
   status: string;
 }
-
-export type UserLoginType = 'emailUser' | 'kakaoUser' | null;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,8 @@ export default defineConfig({
         target: 'http://54.180.112.35:8080',
         changeOrigin: true,
         secure: false,
-        ws: true,
+        // 웹소켓 설정
+        // ws: true,
       },
     },
   },


### PR DESCRIPTION
## 📌 관련 이슈
- close #95 

## 📝 변경 사항
### AS-IS
- 로그아웃 기능의 부재
- 로그인 유저 타입 분류의 부재
- 전역 변수로 토큰 관리

### TO-BE
- 로그인 유저 타입 분류(이메일 로그인 회원/카카오 로그인 회원)
- 로컬 스토리지에 토큰 저장
- 로그 아웃시 로컬 스토리지에서 토큰 및 로그인 유저 타입 삭제
- 로그인 유저 타입에 따라 호출 api 분리해서 호출
- 인증코드 페이지에서 불필요한 onblur 속성 삭제

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
카카오 로그아웃은 프로필 생성 여부 검증하므로 인터셉터 이용해서 프로필 생성페이지 이동하게 만든 후 다시 로직 검증하겠습니다.
