### PR TITLE
♻️ [Refactor] 프로필 조회 API 호출 실패 시 재요청하는 로직 수정

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,11 +4,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import logo from '../../assets/svg/logo.svg';
 import { notifications } from '../../mocks/notifications';
 import { Notification } from '../../types/Notification';
-import axios from 'axios';
+import axiosInstance from '../../api/axiosInstance';
 
 const Header = () => {
   const navigate = useNavigate();
-  const userLoginType = localStorage.getItem('loginUserType');
   const accessToken = localStorage.getItem('accessToken');
 
   const handleNavigateMypage = () => {
@@ -17,33 +16,13 @@ const Header = () => {
 
   const handleLogout = async () => {
     try {
-      if (userLoginType === 'emailUser') {
-        const response = await axios.delete('/api/v1/users/logout', {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        });
-        console.log(response.data);
-        alert(response.data.message);
+      const response = await axiosInstance.delete('/api/v1/users/logout');
+      alert(response.data.message);
 
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('loginUserType');
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('loginUserType');
 
-        navigate('/');
-      } else if (userLoginType === 'kakaoUser') {
-        const response = await axios.delete('/api/v1/kakao/logout', {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        });
-        console.log(response.data);
-        alert(response.data.message);
-
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('loginUserType');
-
-        navigate('/');
-      }
+      navigate('/');
     } catch (err) {
       console.error('로그아웃 실패:', err);
     }

--- a/src/components/Join/RedirectResetPassword.tsx
+++ b/src/components/Join/RedirectResetPassword.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
+import axiosInstance from '../../api/axiosInstance';
+import JoinField from './JoinField';
+import {
+  handleValidation,
+  validatePassword,
+  validatePasswordConfirm,
+} from './validation';
+import { passwordErrorMessages } from '../../types/Errors';
+
+const RedirectResetPassword = () => {
+  const navigate = useNavigate();
+  const [password, setPassword] = useState<string>('');
+  const [passwordConfirm, setPasswordConfirm] = useState<string>('');
+  const [errors, setErrors] = useState<passwordErrorMessages>({
+    passwordError: null,
+    passwordConfirmError: null,
+  });
+
+  const setValidationErrors = () => {
+    setErrors({
+      passwordError: validatePassword(password),
+      passwordConfirmError: validatePasswordConfirm(password, passwordConfirm),
+    });
+  };
+
+  const token = new URL(window.location.href).searchParams.get('token');
+
+  const fetchAccessToken = async () => {
+    try {
+      await axiosInstance.post('/api/v1/users/password/change', {
+        token: token,
+        newPassword: password,
+      });
+
+      alert('비밀번호가 변경되었습니다. 다시 로그인해주세요.');
+      setValidationErrors();
+      navigate('/login');
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        console.log(err.message);
+      }
+    }
+  };
+
+  return (
+    <div className="w-full h-screen flex justify-center items-center">
+      <div className="max-w-[538px] flex gap-x-6">
+        <form className="w-[320px] flex flex-col gap-4">
+          <JoinField
+            name="password"
+            label="비밀번호"
+            type="password"
+            value={password}
+            onChange={e => {
+              setPassword(e.target.value);
+            }}
+            onBlur={e => {
+              handleValidation(
+                e.target.name,
+                e.target.value,
+                validatePassword,
+                setErrors
+              );
+            }}
+            error={errors.passwordError}
+            placeholder="새로운 비밀번호를 입력해주세요."
+            required
+          />
+          <JoinField
+            name="passwordConfirm"
+            label="비밀번호 확인"
+            type="password"
+            value={passwordConfirm}
+            onChange={e => {
+              setPasswordConfirm(e.target.value);
+            }}
+            onBlur={e =>
+              handleValidation(
+                e.target.name,
+                e.target.value,
+                value => validatePasswordConfirm(password, value),
+                setErrors
+              )
+            }
+            error={errors.passwordConfirmError}
+            placeholder="새로운 비밀번호를 다시 한 번 입력해주세요."
+            required
+          />
+          <button
+            type="button"
+            onClick={fetchAccessToken}
+            disabled={!password || !passwordConfirm}
+            className="btn btn-primary"
+          >
+            비밀번호 재설정
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default RedirectResetPassword;

--- a/src/components/Join/ResetPassword.tsx
+++ b/src/components/Join/ResetPassword.tsx
@@ -1,23 +1,36 @@
 import { useState } from 'react';
 import Input from '../Input';
-import { Link } from 'react-router-dom';
+import axiosInstance from '../../api/axiosInstance';
+import { AxiosError } from 'axios';
 
 const ResetPassword = () => {
   const [email, setEmail] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  const handleResetPassword = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleResetPassword = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log('제출완료', email);
-    setError(null);
 
-    setSuccess(
-      '입력하신 이메일로 비밀번호 재설정 링크가 발송되었습니다. 메일을 확인해주세요.'
-    );
+    try {
+      await axiosInstance.post('/api/v1/users/password/change/link-send', {
+        email: email,
+      });
 
-    // error test
-    // setError('입력하신 이메일로 가입된 계정이 없습니다.');
+      setError(null);
+
+      setSuccess(
+        '입력하신 이메일로 비밀번호 재설정 링크가 발송되었습니다. 메일을 확인해주세요.'
+      );
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        // TODO: 오류 코드 확인 필요
+        setError('입력하신 이메일로 가입된 계정이 없습니다.');
+      }
+    }
+  };
+
+  const handleConfirmBtn = () => {
+    setSuccess(null);
   };
 
   return (
@@ -61,9 +74,12 @@ const ResetPassword = () => {
             </svg>
             <p className="w-full font-bold text-sm text-center">{success}</p>
             <div>
-              <Link to="/login" className="w-full">
-                <button className="btn btn-sm btn-primary">확인</button>
-              </Link>
+              <button
+                className="btn btn-sm btn-primary"
+                onClick={handleConfirmBtn}
+              >
+                확인
+              </button>
             </div>
           </div>
         )}

--- a/src/components/Login/KakaoLogin.tsx
+++ b/src/components/Login/KakaoLogin.tsx
@@ -15,7 +15,6 @@ const KakaoLogin = () => {
         });
 
         localStorage.setItem('accessToken', response.data.accessToken);
-        localStorage.setItem('loginUserType', 'kakaoUser');
 
         navigate('/');
       } catch (err) {

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -22,7 +22,6 @@ const LoginForm = () => {
 
       if (response.data && response.data.accessToken) {
         localStorage.setItem('accessToken', response.data.accessToken);
-        localStorage.setItem('loginUserType', 'emailUser');
       }
 
       navigate('/');

--- a/src/components/MyPage/MyProfile.tsx
+++ b/src/components/MyPage/MyProfile.tsx
@@ -81,6 +81,10 @@ const MyProfile = () => {
     );
   }
 
+  if (hasProfile === 'false') {
+    return <ProfileRedirect />;
+  }
+
   return hasProfile === 'true' ? (
     <div className="w-full">
       <div className="w-[680px] m-auto flex flex-col items-center mt-[30px]">
@@ -143,9 +147,7 @@ const MyProfile = () => {
       </div>
     </div>
   ) : (
-    <>
-      <ProfileRedirect />
-    </>
+    <></>
   );
 };
 

--- a/src/hooks/useFetchUserProfile.ts
+++ b/src/hooks/useFetchUserProfile.ts
@@ -12,6 +12,7 @@ const useFetchUserProfile = () => {
   return useQuery<UserProfile, AxiosError>({
     queryKey: ['UserProfile'],
     queryFn: fetchUserProfile,
+    retry: false,
   });
 };
 

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -15,6 +15,7 @@ import MyPage from '../pages/MyPage';
 import ResetPasswordPage from '../pages/ResetPasswordPage';
 import UserProfilePage from '../pages/UserProfilePage';
 import ViewParticipantPage from '../pages/ViewParticipantPage';
+import RedirectResetPassword from '../components/Join/RedirectResetPassword';
 
 const queryClient = new QueryClient();
 import VerifyEmailCode from '../components/Join/VerifyEmailCode';
@@ -35,6 +36,10 @@ const Router = () => {
           <Route path="/verify-email-code" element={<VerifyEmailCode />} />
           <Route path="/create-profile" element={<CreateProfilePage />} />
           <Route path="/reset-password" element={<ResetPasswordPage />} />
+          <Route
+            path="/reset-password/callback"
+            element={<RedirectResetPassword />}
+          />
           <Route path="/kakao/callback" element={<KakaoLogin />} />
           {/* 마이페이지 */}
           <Route path="/mypage" element={<MyPage />}>


### PR DESCRIPTION
## 📌 관련 이슈
- close #115 

## 📝 변경 사항
### AS-IS
- 프로필 조회 API 호출 실패 시 서버에 API 재호출 함
- 프로필 검증 오류를 나타내는 localstorage에 저장된 hasProfile에 대해 오류 처리 부족

### TO-BE
- 프로필 조회 API 호출 실패 시 서버에 API 재호출 하지 않도록 react-query 옵션값 수정
-  프로필 검증 오류를 나타내는 hasProfile === 'false' 에 대한 값을 추가하여 ProfileRedirect 컴포넌트 호출 처리를 분기함


## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
