### PR TITLE
✨ [Feat] 비밀번호 재설정 기능 구현

### DIFF
--- a/src/components/Join/RedirectResetPassword.tsx
+++ b/src/components/Join/RedirectResetPassword.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
 import axiosInstance from '../../api/axiosInstance';
-import JoinField from '../Join/JoinField';
+import JoinField from './JoinField';
 import {
   handleValidation,
   validatePassword,
@@ -10,7 +10,7 @@ import {
 } from './validation';
 import { passwordErrorMessages } from '../../types/Errors';
 
-const ResetPasswordCallback = () => {
+const RedirectResetPassword = () => {
   const navigate = useNavigate();
   const [password, setPassword] = useState<string>('');
   const [passwordConfirm, setPasswordConfirm] = useState<string>('');
@@ -103,4 +103,4 @@ const ResetPasswordCallback = () => {
   );
 };
 
-export default ResetPasswordCallback;
+export default RedirectResetPassword;

--- a/src/components/Join/ResetPassword.tsx
+++ b/src/components/Join/ResetPassword.tsx
@@ -1,23 +1,36 @@
 import { useState } from 'react';
 import Input from '../Input';
-import { Link } from 'react-router-dom';
+import axiosInstance from '../../api/axiosInstance';
+import { AxiosError } from 'axios';
 
 const ResetPassword = () => {
   const [email, setEmail] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  const handleResetPassword = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleResetPassword = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log('제출완료', email);
-    setError(null);
 
-    setSuccess(
-      '입력하신 이메일로 비밀번호 재설정 링크가 발송되었습니다. 메일을 확인해주세요.'
-    );
+    try {
+      await axiosInstance.post('/api/v1/users/password/change/link-send', {
+        email: email,
+      });
 
-    // error test
-    // setError('입력하신 이메일로 가입된 계정이 없습니다.');
+      setError(null);
+
+      setSuccess(
+        '입력하신 이메일로 비밀번호 재설정 링크가 발송되었습니다. 메일을 확인해주세요.'
+      );
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        // TODO: 오류 코드 확인 필요
+        setError('입력하신 이메일로 가입된 계정이 없습니다.');
+      }
+    }
+  };
+
+  const handleConfirmBtn = () => {
+    setSuccess(null);
   };
 
   return (
@@ -61,9 +74,12 @@ const ResetPassword = () => {
             </svg>
             <p className="w-full font-bold text-sm text-center">{success}</p>
             <div>
-              <Link to="/login" className="w-full">
-                <button className="btn btn-sm btn-primary">확인</button>
-              </Link>
+              <button
+                className="btn btn-sm btn-primary"
+                onClick={handleConfirmBtn}
+              >
+                확인
+              </button>
             </div>
           </div>
         )}

--- a/src/components/Join/ResetPasswordCallback.tsx
+++ b/src/components/Join/ResetPasswordCallback.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
+import axiosInstance from '../../api/axiosInstance';
+import JoinField from '../Join/JoinField';
+import {
+  handleValidation,
+  validatePassword,
+  validatePasswordConfirm,
+} from './validation';
+import { passwordErrorMessages } from '../../types/Errors';
+
+const ResetPasswordCallback = () => {
+  const navigate = useNavigate();
+  const [password, setPassword] = useState<string>('');
+  const [passwordConfirm, setPasswordConfirm] = useState<string>('');
+  const [errors, setErrors] = useState<passwordErrorMessages>({
+    passwordError: null,
+    passwordConfirmError: null,
+  });
+
+  const setValidationErrors = () => {
+    setErrors({
+      passwordError: validatePassword(password),
+      passwordConfirmError: validatePasswordConfirm(password, passwordConfirm),
+    });
+  };
+
+  const token = new URL(window.location.href).searchParams.get('token');
+
+  const fetchAccessToken = async () => {
+    try {
+      await axiosInstance.post('/api/v1/users/password/change', {
+        token: token,
+        newPassword: password,
+      });
+
+      alert('비밀번호가 변경되었습니다. 다시 로그인해주세요.');
+      setValidationErrors();
+      navigate('/login');
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        console.log(err.message);
+      }
+    }
+  };
+
+  return (
+    <div className="w-full h-screen flex justify-center items-center">
+      <div className="max-w-[538px] flex gap-x-6">
+        <form className="w-[320px] flex flex-col gap-4">
+          <JoinField
+            name="password"
+            label="비밀번호"
+            type="password"
+            value={password}
+            onChange={e => {
+              setPassword(e.target.value);
+            }}
+            onBlur={e => {
+              handleValidation(
+                e.target.name,
+                e.target.value,
+                validatePassword,
+                setErrors
+              );
+            }}
+            error={errors.passwordError}
+            placeholder="새로운 비밀번호를 입력해주세요."
+            required
+          />
+          <JoinField
+            name="passwordConfirm"
+            label="비밀번호 확인"
+            type="password"
+            value={passwordConfirm}
+            onChange={e => {
+              setPasswordConfirm(e.target.value);
+            }}
+            onBlur={e =>
+              handleValidation(
+                e.target.name,
+                e.target.value,
+                value => validatePasswordConfirm(password, value),
+                setErrors
+              )
+            }
+            error={errors.passwordConfirmError}
+            placeholder="새로운 비밀번호를 다시 한 번 입력해주세요."
+            required
+          />
+          <button
+            type="button"
+            onClick={fetchAccessToken}
+            disabled={!password || !passwordConfirm}
+            className="btn btn-primary"
+          >
+            비밀번호 재설정
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPasswordCallback;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -15,7 +15,7 @@ import MyPage from '../pages/MyPage';
 import ResetPasswordPage from '../pages/ResetPasswordPage';
 import UserProfilePage from '../pages/UserProfilePage';
 import ViewParticipantPage from '../pages/ViewParticipantPage';
-import ResetPasswordCallback from '../components/Join/ResetPasswordCallback';
+import RedirectResetPassword from '../components/Join/RedirectResetPassword';
 
 const queryClient = new QueryClient();
 import VerifyEmailCode from '../components/Join/VerifyEmailCode';
@@ -38,7 +38,7 @@ const Router = () => {
           <Route path="/reset-password" element={<ResetPasswordPage />} />
           <Route
             path="/reset-password/callback"
-            element={<ResetPasswordCallback />}
+            element={<RedirectResetPassword />}
           />
           <Route path="/kakao/callback" element={<KakaoLogin />} />
           {/* 마이페이지 */}

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -15,6 +15,7 @@ import MyPage from '../pages/MyPage';
 import ResetPasswordPage from '../pages/ResetPasswordPage';
 import UserProfilePage from '../pages/UserProfilePage';
 import ViewParticipantPage from '../pages/ViewParticipantPage';
+import ResetPasswordCallback from '../components/Join/ResetPasswordCallback';
 
 const queryClient = new QueryClient();
 import VerifyEmailCode from '../components/Join/VerifyEmailCode';
@@ -35,6 +36,10 @@ const Router = () => {
           <Route path="/verify-email-code" element={<VerifyEmailCode />} />
           <Route path="/create-profile" element={<CreateProfilePage />} />
           <Route path="/reset-password" element={<ResetPasswordPage />} />
+          <Route
+            path="/reset-password/callback"
+            element={<ResetPasswordCallback />}
+          />
           <Route path="/kakao/callback" element={<KakaoLogin />} />
           {/* 마이페이지 */}
           <Route path="/mypage" element={<MyPage />}>


### PR DESCRIPTION
## 📌 관련 이슈
- close #121 

## 📝 변경 사항
### AS-IS
- 비밀번호 재설정 링크 발송 컴포넌트만 존재
- 비밀번호 재설정 콜백 컴포넌트 부재
- 서버 연동 필요

### TO-BE
- 비밀번호 재설정 링크 발송 api 연동
- 비밀번호 재설정 api 연동
- 이메일 입력 -> 재설정 링크 전송
- 메일에서 재설정 링크로 ResetPasswordCallback으로 리다이렉트하도록 설정
- 비밀번호 유효성 검증 이후 비밀번호 재설정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
후순위로 미룬 작업 : useMutation 사용해서 상태 리팩토링 하려고 합니다.