### PR TITLE
✨ Feat: 상세페이지 레이아웃 컴포넌트 구현

### DIFF
--- a/src/components/DetailPageLayout.tsx
+++ b/src/components/DetailPageLayout.tsx
@@ -84,7 +84,7 @@ const DetailPageLayout = ({
                 />
               </Map>
             </div>
-            <div className="flex justify-end mt-auto ml-auto mt-10">
+            <div className="flex justify-end ml-auto mt-10">
               <button
                 type="button"
                 className="btn btn-primary"

--- a/src/components/DetailPageLayout.tsx
+++ b/src/components/DetailPageLayout.tsx
@@ -1,0 +1,103 @@
+import { Map, MapMarker } from 'react-kakao-maps-sdk';
+import Categories from '../components/Categories';
+import type { CreateMeetingResponse } from '../types/Meeting';
+import FormField from '../components/FormField';
+import { formatDate } from '../utils/formatDate';
+
+const DetailPageLayout = ({
+  meeting,
+  buttonLabel,
+  onClick,
+}: {
+  meeting: CreateMeetingResponse;
+  buttonLabel: string;
+  onClick: () => void;
+}) => {
+  return (
+    <div className="flex justify-center px-16 py-10">
+      <div className="w-full max-w-5xl px-14">
+        <h1 className="text-2xl font-bold mb-6 text-center">{meeting.title}</h1>
+        <div className="flex gap-x-8 justify-center">
+          <div className="space-y-4">
+            <FormField
+              label="모임 날짜"
+              type="datetime-local"
+              value={formatDate(meeting.meetingDateTime)}
+              name="meetingDateTime"
+              readOnly
+            />
+            <FormField
+              label="모임 인원"
+              type="number"
+              value={meeting.maxCount}
+              name="maxCount"
+              readOnly
+            />
+            <FormField
+              label="주소"
+              type="text"
+              value={meeting.address}
+              name="address"
+              readOnly
+            />
+            <div className="form-control">
+              <div className="label">
+                <span className="label-text font-bold">카테고리</span>
+              </div>
+              <Categories
+                selectedCategories={meeting.category}
+                size="xs"
+                readOnly
+              />
+            </div>
+            <label className="form-control">
+              <div className="label">
+                <span className="label-text font-bold">내용</span>
+              </div>
+              <div className={`p-3 rounded-md bg-gray-50 w-[320px] text-sm`}>
+                {meeting.content}
+              </div>
+            </label>
+          </div>
+          <div className="flex flex-col justify-between items-center">
+            <div>
+              <img
+                src={meeting.thumbnail || '/image/thumbnail_default.webp'}
+                alt="Thumbnail"
+                className="w-[280px] h-[178.48px] object-cover rounded-3xl"
+              />
+            </div>
+            <div className="mt-4">
+              <Map
+                center={{
+                  lat: meeting.latitude,
+                  lng: meeting.longitude,
+                }}
+                className="w-[320px] h-[280px]"
+                level={5}
+              >
+                <MapMarker
+                  position={{
+                    lat: meeting.latitude,
+                    lng: meeting.longitude,
+                  }}
+                />
+              </Map>
+            </div>
+            <div className="flex justify-end mt-auto ml-auto mt-10">
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={onClick}
+              >
+                {buttonLabel}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DetailPageLayout;

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -1,7 +1,7 @@
 const FormField = ({
   label,
   type,
-  size = 'xs',
+  size = 320,
   value,
   name,
   onChange,
@@ -10,35 +10,44 @@ const FormField = ({
   max,
   minLength,
   maxLength,
+  readOnly = false,
 }: {
   label: string;
   type: string;
-  size?: string;
-  value: string | number;
+  size?: number;
+  value?: string | number;
   name?: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   required?: boolean;
   min?: number | string;
   max?: number | string;
   minLength?: number;
   maxLength?: number;
+  readOnly?: boolean;
 }) => (
   <label className="form-control">
     <div className="label">
       <span className="label-text font-bold">{label}</span>
     </div>
-    <input
-      type={type}
-      className={`input input-bordered max-w-${size} text-sm`}
-      value={value}
-      name={name}
-      onChange={onChange}
-      required={required}
-      min={min}
-      max={max}
-      minLength={minLength}
-      maxLength={maxLength}
-    />
+    {readOnly ? (
+      <div className={`p-3 rounded-md bg-gray-50 w-[${size}px] text-sm`}>
+        {value}
+      </div>
+    ) : (
+      <input
+        type={type}
+        className={`input input-bordered w-[${size}px] text-sm`}
+        value={value}
+        name={name}
+        onChange={onChange}
+        required={required}
+        min={min}
+        max={max}
+        minLength={minLength}
+        maxLength={maxLength}
+        readOnly={readOnly}
+      />
+    )}
   </label>
 );
 

--- a/src/pages/ApplyMeetingPage.tsx
+++ b/src/pages/ApplyMeetingPage.tsx
@@ -1,114 +1,16 @@
-import { Map, MapMarker } from 'react-kakao-maps-sdk';
-import Categories from '../components/Categories';
+import DetailPageLayout from '../components/DetailPageLayout';
 import type { CreateMeetingResponse } from '../types/Meeting';
 
 const ApplyMeetingPage = ({ meeting }: { meeting: CreateMeetingResponse }) => {
   const hasApplied = false; // TODO
+  const handleClick = () => {};
 
   return (
-    <div className="flex justify-center px-16 py-10">
-      <div className="w-full max-w-5xl px-14">
-        <h1 className="text-2xl font-bold mb-6 text-center">{meeting.title}</h1>
-        <div className="flex gap-x-8 justify-center">
-          <div className="space-y-4">
-            <div className="form-control">
-              <label className="label">
-                <span className="label-text font-bold">모임 날짜</span>
-              </label>
-              <input
-                type="datetime-local"
-                value={meeting.meetingDateTime}
-                readOnly
-                className="input input-bordered"
-              />
-            </div>
-            <div className="form-control">
-              <label className="label">
-                <span className="label-text font-bold">모임 인원</span>
-              </label>
-              <input
-                type="number"
-                value={meeting.maxCount}
-                readOnly
-                className="input input-bordered"
-              />
-            </div>
-            <div className="form-control gap-y-4">
-              <div className="label">
-                <span className="label-text font-bold">장소</span>
-              </div>
-              <input
-                type="text"
-                value={meeting.title}
-                readOnly
-                className="input input-bordered"
-              />
-              <input
-                type="text"
-                value={meeting.address}
-                readOnly
-                className="input input-bordered"
-              />
-            </div>
-            <div className="form-control">
-              <div className="label">
-                <span className="label-text font-bold">카테고리</span>
-              </div>
-              <Categories
-                selectedCategories={meeting.category}
-                size="xs"
-                readOnly
-              />
-            </div>
-            <label className="form-control">
-              <div className="label">
-                <span className="label-text font-bold">내용</span>
-              </div>
-              <textarea
-                className="textarea textarea-bordered max-w-sm text-sm"
-                rows={4}
-                value={meeting.content}
-                readOnly
-              />
-            </label>
-          </div>
-          <div className="flex flex-col justify-between">
-            <div>
-              <img
-                src={
-                  '/image/placeholder_thumbnail.webp'
-                  // meeting.thumbnail || 'image/thumbnail_default.webp'
-                }
-                alt="Thumbnail"
-                className="w-[280px] h-[178.48px] object-cover rounded-3xl"
-              />
-            </div>
-            <div className="mt-4">
-              <Map
-                center={{
-                  lat: meeting.latitude,
-                  lng: meeting.longitude,
-                }}
-                className="w-[280px] h-[280px]"
-                level={5}
-              >
-                <MapMarker
-                  position={{
-                    lat: meeting.latitude,
-                    lng: meeting.longitude,
-                  }}
-                />
-              </Map>
-            </div>
-            <div className="flex justify-end mt-auto">
-              <button type="button" className="btn btn-primary">
-                {hasApplied ? '신청취소' : '신청'}
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <DetailPageLayout
+      meeting={meeting}
+      buttonLabel={hasApplied ? '신청취소' : '신청'}
+      onClick={handleClick}
+    />
   );
 };
 

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -1,17 +1,27 @@
 import React, { useEffect, useState } from 'react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import Categories from '../components/Categories';
+import DetailPageLayout from '../components/DetailPageLayout';
+import FormField from '../components/FormField';
+import KakaoMapModal from '../components/modals/KakaoMapModal';
 import useEditMeeting from '../hooks/useEditMeeting';
 import type {
   CreateMeetingRequest,
   CreateMeetingResponse,
 } from '../types/Meeting';
+import type { PlaceDetail } from '../types/Post';
+import {
+  getLocalDateTime,
+  getOneYearLaterDateTime,
+} from '../utils/getLocalDateTime';
 
 const PostEditPage = ({ meeting }: { meeting: CreateMeetingResponse }) => {
   const id = meeting.id;
   const { mutate: editMeeting } = useEditMeeting();
   const [isEditMode, setIsEditMode] = useState(false);
   const [editData, setEditData] = useState<CreateMeetingRequest>();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedPlace, setSelectedPlace] = useState<PlaceDetail | null>(null);
 
   useEffect(() => {
     if (meeting) {
@@ -46,10 +56,29 @@ const PostEditPage = ({ meeting }: { meeting: CreateMeetingResponse }) => {
     setIsEditMode(false);
   };
 
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+  const updateLocation = (
+    locationId: string,
+    latitude: string,
+    longitude: string,
+    address: string
+  ) => {
+    if (!editData) return;
+    setEditData({
+      ...editData,
+      locationId: Number(locationId),
+      latitude: Number(latitude),
+      longitude: Number(longitude),
+      address,
+    });
+  };
+
   const handleEdit = () => setIsEditMode(true);
   const handleCancel = () => backToReadOnly();
   const handleSave = () => {
     if (!id || !editData) return;
+    console.log({ editData });
     editMeeting(
       { id: id.toString(), body: editData },
       {
@@ -83,6 +112,12 @@ const PostEditPage = ({ meeting }: { meeting: CreateMeetingResponse }) => {
     setEditData({ ...editData, [name]: value });
   };
 
+  const handleSearchPlace = (place: PlaceDetail) => {
+    setSelectedPlace(place);
+    updateLocation(place.id, place.y, place.x, place.address_name);
+    closeModal();
+  };
+
   const handleToggleCategory = (categoryName: string) => {
     if (!editData) return;
     if (editData.category.includes(categoryName)) {
@@ -99,57 +134,98 @@ const PostEditPage = ({ meeting }: { meeting: CreateMeetingResponse }) => {
   };
 
   if (!editData) return <div>데이터를 불러올 수 없습니다.</div>;
-  // ----------------------------------------------------------------------
-  // 1) 읽기 전용 UI
-  // ----------------------------------------------------------------------
+
   if (!isEditMode) {
     return (
+      <DetailPageLayout
+        meeting={meeting}
+        buttonLabel="수정"
+        onClick={handleEdit}
+      />
+    );
+  }
+
+  return (
+    <>
       <div className="flex justify-center px-16 py-10">
         <div className="w-full max-w-5xl px-14">
-          <div className="flex gap-x-8 justify-center">
+          <form
+            onSubmit={e => e.preventDefault()}
+            className="flex gap-x-8 justify-center"
+          >
             <div className="space-y-4">
-              <div>
-                <label className="font-bold">제목</label>
-                <div className="mt-1 p-2 border rounded-md bg-gray-50">
-                  {meeting.title}
+              <FormField
+                label="제목"
+                type="text"
+                value={editData.title}
+                name="title"
+                onChange={handleInputChange}
+                minLength={1}
+                maxLength={60}
+              />
+              <FormField
+                label="모임 날짜"
+                type="datetime-local"
+                value={editData.meetingDateTime}
+                name="meetingDateTime"
+                onChange={handleInputChange}
+                min={getLocalDateTime()}
+                max={getOneYearLaterDateTime()}
+              />
+              <FormField
+                label="모임 인원"
+                type="number"
+                value={editData.maxCount === 0 ? '' : editData.maxCount}
+                name="maxCount"
+                onChange={handleInputChange}
+                min={2}
+                max={99}
+              />
+              <div className="form-control gap-y-4">
+                <div className="label">
+                  <span className="label-text font-bold">장소</span>
                 </div>
-              </div>
-              <div>
-                <label className="font-bold">모임 날짜</label>
-                <div className="mt-1 p-2 border rounded-md bg-gray-50">
-                  {meeting.meetingDateTime}
-                </div>
-              </div>
-              <div>
-                <label className="font-bold">모임 인원</label>
-                <div className="mt-1 p-2 border rounded-md bg-gray-50">
-                  {meeting.maxCount}명
-                </div>
-              </div>
-              <div>
-                <label className="font-bold">장소</label>
-                <div className="mt-1 p-2 border rounded-md bg-gray-50">
-                  {meeting.address}
-                </div>
+                <input
+                  type="text"
+                  value={selectedPlace?.place_name || ''}
+                  placeholder="장소"
+                  readOnly
+                  className="input input-bordered"
+                />
+                <input
+                  type="text"
+                  value={selectedPlace?.address_name || editData.address}
+                  placeholder="주소"
+                  readOnly
+                  className="input input-bordered"
+                />
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={openModal}
+                >
+                  모임 장소 찾기
+                </button>
               </div>
               <div>
                 <label className="font-bold">카테고리</label>
-                <div className="mt-1">
-                  <Categories
-                    selectedCategories={meeting.category}
-                    size="xs"
-                    readOnly
-                  />
-                </div>
+                <Categories
+                  selectedCategories={editData.category}
+                  toggleCategory={handleToggleCategory}
+                  size="xs"
+                />
               </div>
               <div>
                 <label className="font-bold">내용</label>
-                <div className="mt-1 p-2 border rounded-md bg-gray-50 whitespace-pre-wrap">
-                  {meeting.content}
-                </div>
+                <textarea
+                  name="content"
+                  className="textarea textarea-bordered w-full"
+                  rows={4}
+                  value={editData.content}
+                  onChange={handleInputChange}
+                />
               </div>
             </div>
-
             <div className="flex flex-col justify-between">
               <div>
                 <img
@@ -161,153 +237,44 @@ const PostEditPage = ({ meeting }: { meeting: CreateMeetingResponse }) => {
               <div className="mt-4">
                 <Map
                   center={{
-                    lat: meeting.latitude,
-                    lng: meeting.longitude,
+                    lat: editData.latitude,
+                    lng: editData.longitude,
                   }}
                   className="w-[280px] h-[280px]"
                   level={5}
                 >
                   <MapMarker
                     position={{
-                      lat: meeting.latitude,
-                      lng: meeting.longitude,
+                      lat: editData.latitude,
+                      lng: editData.longitude,
                     }}
                   />
                 </Map>
               </div>
-              <div className="flex justify-end mt-auto">
+              <div className="flex justify-end mt-auto gap-x-2">
                 <button
                   type="button"
-                  className="btn btn-primary"
-                  onClick={handleEdit}
+                  className="btn btn-ghost"
+                  onClick={handleCancel}
                 >
-                  수정
+                  취소
+                </button>
+                <button
+                  type="submit"
+                  className="btn btn-primary"
+                  onClick={handleSave}
+                >
+                  저장
                 </button>
               </div>
             </div>
-          </div>
+          </form>
         </div>
       </div>
-    );
-  }
-
-  // ----------------------------------------------------------------------
-  // 2) 편집 모드 UI
-  // ----------------------------------------------------------------------
-  return (
-    <div className="flex justify-center px-16 py-10">
-      <div className="w-full max-w-5xl px-14">
-        <form
-          onSubmit={e => e.preventDefault()}
-          className="flex gap-x-8 justify-center"
-        >
-          <div className="space-y-4">
-            <div>
-              <label className="font-bold">제목</label>
-              <input
-                type="text"
-                name="title"
-                className="input input-bordered w-full"
-                value={editData.title}
-                onChange={handleInputChange}
-              />
-            </div>
-            <div>
-              <label className="font-bold">모임 날짜</label>
-              <input
-                type="datetime-local"
-                name="meetingDateTime"
-                className="input input-bordered w-full"
-                value={editData.meetingDateTime}
-                onChange={handleInputChange}
-              />
-            </div>
-            <div>
-              <label className="font-bold">모임 인원</label>
-              <input
-                type="number"
-                name="maxCount"
-                min={2}
-                max={99}
-                className="input input-bordered w-full"
-                value={editData.maxCount}
-                onChange={handleInputChange}
-              />
-            </div>
-            <div>
-              <label className="font-bold">장소</label>
-              <input
-                type="text"
-                name="address"
-                className="input input-bordered w-full"
-                value={editData.address}
-                onChange={handleInputChange}
-              />
-            </div>
-            <div>
-              <label className="font-bold">카테고리</label>
-              <Categories
-                selectedCategories={editData.category}
-                toggleCategory={handleToggleCategory}
-                size="xs"
-              />
-            </div>
-            <div>
-              <label className="font-bold">내용</label>
-              <textarea
-                name="content"
-                className="textarea textarea-bordered w-full"
-                rows={4}
-                value={editData.content}
-                onChange={handleInputChange}
-              />
-            </div>
-          </div>
-          <div className="flex flex-col justify-between">
-            <div>
-              <img
-                src={meeting.thumbnail || 'image/upload_image.webp'}
-                alt="Thumbnail"
-                className="w-[280px] h-[178.48px] object-cover rounded-3xl"
-              />
-            </div>
-            <div className="mt-4">
-              <Map
-                center={{
-                  lat: editData.latitude,
-                  lng: editData.longitude,
-                }}
-                className="w-[280px] h-[280px]"
-                level={5}
-              >
-                <MapMarker
-                  position={{
-                    lat: editData.latitude,
-                    lng: editData.longitude,
-                  }}
-                />
-              </Map>
-            </div>
-            <div className="flex justify-end mt-auto gap-x-2">
-              <button
-                type="button"
-                className="btn btn-ghost"
-                onClick={handleCancel}
-              >
-                취소
-              </button>
-              <button
-                type="submit"
-                className="btn btn-primary"
-                onClick={handleSave}
-              >
-                저장
-              </button>
-            </div>
-          </div>
-        </form>
-      </div>
-    </div>
+      {isModalOpen && (
+        <KakaoMapModal onClose={closeModal} onSearch={handleSearchPlace} />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #123 

## 📝 변경 사항
- 상세페이지의 레이아웃이 비슷해 각 파일마다 동일한 코드가 반복됨

### TO-BE
- 레이아웃 페이지 구현
- FormField 읽기전용 모드 추가 및 스타일 수정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/931fa423-f12b-47f2-b84d-34d549281204)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
