### PR TITLE
♻️ [Refactor] 비밀번호 재설정 컴포넌트 상태 관리 개선

### DIFF
--- a/src/components/Join/RedirectResetPassword.tsx
+++ b/src/components/Join/RedirectResetPassword.tsx
@@ -93,7 +93,7 @@ const RedirectResetPassword = () => {
             type="button"
             onClick={fetchAccessToken}
             disabled={!password || !passwordConfirm}
-            className="btn btn-primary"
+            className="btn btn-block font-bold text-[16px] btn-primary border-none"
           >
             비밀번호 재설정
           </button>


### PR DESCRIPTION
## 📌 관련 이슈
- close #147 

## 📝 변경 사항
### AS-IS
- 비밀번호 재설정 링크 발송 시 pending 상태를 나타내는 ui의 부재

### TO-BE
- 비밀번호 재설정 링크 발송 시 pending 상태를 나타내도록 버튼 ui 수정
- 비밀번호 재설정 버튼 UI 통일

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="402" alt="스크린샷 2025-01-19 오전 12 42 33" src="https://github.com/user-attachments/assets/18e6d945-0c44-4487-9f6a-e87b4770bc94" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
