### PR TITLE
♻️ [Refactor] 채팅방 리스트 UI 개선

### DIFF
--- a/src/components/Chat/ChatList.tsx
+++ b/src/components/Chat/ChatList.tsx
@@ -13,9 +13,9 @@ const ChatList: React.FC<ChatListProps> = ({ chats, onChatClick }) => {
   return (
     <>
       <div className="relative w-full font-bold text-xl flex items-center justify-center border-b-[1px] border-gray-300 pb-5 pt-1">
-        <span className="block">채팅</span>
+        <span className="block cursor-default">채팅</span>
         <button
-          className="absolute right-4 text-gray-500 hover:text-gray-800"
+          className="absolute right-1 text-gray-500 hover:text-gray-800"
           onClick={() => setIsChatModalOpen(false)}
           aria-label="닫기"
         >
@@ -31,27 +31,25 @@ const ChatList: React.FC<ChatListProps> = ({ chats, onChatClick }) => {
               onClick={() => onChatClick(chat)}
             >
               <img
-                src={chat.meetingThumbnail}
+                src={
+                  chat.meetingThumbnailUrl ||
+                  '/image/default_profile_image_test.webp'
+                }
                 alt="Chatting Room Thumbnail"
-                className="w-10 h-10 rounded-full border-[1px] border-black bg-white p-1 mr-2"
+                className="w-10 h-10 rounded-full border-[1px] border-gray-400 bg-white p-1 mr-2"
               />
-              <div className="flex flex-1">
-                <div>
-                  <span className="font-bold text-[16px]">
-                    {chat.meetingTitle}
-                  </span>
-                  <p className="text-sm">{chat.lastMessage}</p>
-                </div>
+              <div className="flex flex-1 gap-2">
+                <span className="font-bold text-sm overflow-hidden text-ellipsis whitespace-nowrap w-[210px]">
+                  {chat.meetingTitle}
+                </span>
               </div>
-              {chat.unreadMessagesCount && (
-                <div className="flex justify-center items-center">
-                  <span className="block bg-primary px-2 py-1 rounded-full font-bold text-xs">
-                    {chat.unreadMessagesCount >= 100
-                      ? '99+'
-                      : chat.unreadMessagesCount}
-                  </span>
-                </div>
-              )}
+              <div className="flex justify-center items-center">
+                <span className="block bg-primary px-2 py-1 rounded-full font-bold text-xs">
+                  {chat.unreadMessagesCount >= 100
+                    ? '99+'
+                    : chat.unreadMessagesCount}
+                </span>
+              </div>
             </li>
           ))}
         </ul>

--- a/src/types/Chat.ts
+++ b/src/types/Chat.ts
@@ -5,19 +5,19 @@ export interface Chat {
   meetingTitle: string;
   lastMessage: string;
   hostId: string;
-  unreadMessagesCount: number | null;
+  unreadMessagesCount: number;
   readerId: string[];
 }
 
 export interface ChatRoomResponse {
   roomId: number;
   meetingId: number;
-  meetingThumbnail: string;
+  meetingThumbnailUrl: string;
   meetingTitle: string;
   lastMessage: string;
   hostId: number;
   readerId: number[];
-  unreadMessagesCount: number | null;
+  unreadMessagesCount: number;
 }
 
 export interface ChatHistoryResponse {


### PR DESCRIPTION
## 📌 관련 이슈
- close #175 

## 📝 변경 사항
### AS-IS
- 썸네일 이미지 null일 경우 처리 부재
- title 길이가 길 경우 2줄로 보임
- unreadMessagesCount의 기본값이 0이므로 조건부 렌더링 개선 필요
- 썸네일 UI 통일 필요

### TO-BE
- 썸네일 이미지 null일 경우 기본 캐릭터 이미지로 변경
- title 길이는 1줄로 고정, 너비보다 길 경우 ... 줄임표 사용
- 응답값의 기본값과 타입 일치 및 키값 일치하도록 수정
- unreadMessagesCount이 존재하는지 확인하는 조건부 렌더링 삭제

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린
변경 전
<img width="337" alt="Image" src="https://github.com/user-attachments/assets/5b6025c9-456c-437e-b8fc-944dc9b38191" />

변경 후
<img width="389" alt="스크린샷 2025-01-20 오후 4 59 49" src="https://github.com/user-attachments/assets/a3b08bde-2fc0-464e-ba29-237baf563ccd" />
샷


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
