### PR TITLE
♻️ [Refactor] Thumbnail을 파일데이터로 보내도록 모집글 생성시 formdata 전달하도록 수정

### DIFF
--- a/src/api/meeting.ts
+++ b/src/api/meeting.ts
@@ -11,9 +11,13 @@ import { apiClient } from './apiClient';
 const COMMON_URL = '/api/v1/meetings';
 
 export const createMeeting = async (
-  form: CreateMeetingRequest
+  form: FormData
 ): Promise<CreateMeetingResponse> =>
-  apiClient({ url: COMMON_URL, method: 'post', data: form });
+  apiClient({
+    url: COMMON_URL,
+    method: 'post',
+    data: form,
+  });
 
 export const editMeeting = async (
   id: string,

--- a/src/hooks/useCreatePostForm.ts
+++ b/src/hooks/useCreatePostForm.ts
@@ -20,7 +20,7 @@ const useCreatePostForm = () => {
     'image/upload_image.webp'
   );
 
-  const { mutate: createMeeting } = useCreateMeeting();
+  const { mutate: createMeeting, isPending } = useCreateMeeting();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -89,6 +89,7 @@ const useCreatePostForm = () => {
     handleInputChange,
     updateLocation,
     updateCategories,
+    isPending,
   };
 };
 

--- a/src/hooks/useCreatePostForm.ts
+++ b/src/hooks/useCreatePostForm.ts
@@ -13,22 +13,45 @@ const useCreatePostForm = () => {
     maxCount: 0,
     category: [],
     content: '',
-    thumbnail: undefined,
   });
+
+  const [thumbnail, setThumbnail] = useState<File | null>(null);
+  const [thumbnailUrl, setThumbnailUrl] = useState<string>(
+    'image/upload_image.webp'
+  );
 
   const { mutate: createMeeting } = useCreateMeeting();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    createMeeting(formData);
+
+    const postFormData = new FormData();
+    postFormData.append(
+      'request',
+      new Blob([JSON.stringify(formData)], { type: 'application/json' })
+    );
+
+    if (thumbnail) {
+      postFormData.append('thumbnail', thumbnail);
+    } else {
+      const defaultThumbnailImage = new File(
+        ['/images/default_profile_image.png'],
+        'default_profile_image.png',
+        { type: 'image/png' }
+      );
+      postFormData.append('profileImage', defaultThumbnailImage);
+    }
+
+    createMeeting(postFormData);
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files ? e.target.files[0] : undefined;
-    setFormData(prev => ({
-      ...prev,
-      thumbnail: file ? URL.createObjectURL(file) : undefined,
-    }));
+    const file = e.target.files ? e.target.files[0] : null;
+    if (file) {
+      setThumbnail(file);
+      const fileUrl = URL.createObjectURL(file);
+      setThumbnailUrl(fileUrl);
+    }
   };
 
   const handleInputChange = (
@@ -58,6 +81,7 @@ const useCreatePostForm = () => {
   };
 
   return {
+    thumbnailUrl,
     formData,
     setFormData,
     handleSubmit,

--- a/src/pages/CreatePostPage.tsx
+++ b/src/pages/CreatePostPage.tsx
@@ -30,6 +30,7 @@ const categoryValueToKey = Object.keys(CategoryList).reduce((acc, key) => {
 
 const CreatePostPage = () => {
   const {
+    thumbnailUrl,
     formData,
     handleSubmit,
     handleFileChange,
@@ -150,7 +151,7 @@ const CreatePostPage = () => {
             <div className="flex flex-col justify-between items-center">
               <label htmlFor="file-upload" className="cursor-pointer">
                 <img
-                  src={formData.thumbnail || 'image/upload_image.webp'}
+                  src={thumbnailUrl || 'image/upload_image.webp'}
                   alt="Thumbnail"
                   className="w-[280px] h-[178.48px] object-cover rounded-3xl"
                 />
@@ -158,7 +159,7 @@ const CreatePostPage = () => {
                   id="file-upload"
                   type="file"
                   className="hidden"
-                  accept="image/*"
+                  accept=".jpg,.jpeg,.png"
                   onChange={handleFileChange}
                 />
               </label>

--- a/src/pages/CreatePostPage.tsx
+++ b/src/pages/CreatePostPage.tsx
@@ -10,6 +10,7 @@ import {
   getLocalDateTime,
   getOneYearLaterDateTime,
 } from '../utils/getLocalDateTime';
+import LoadingSpinner from '../components/LoadingSpinner';
 
 enum CategoryList {
   KOREAN = '한식',
@@ -37,6 +38,7 @@ const CreatePostPage = () => {
     handleInputChange,
     updateLocation,
     updateCategories,
+    isPending,
   } = useCreatePostForm();
 
   const { categories, toggleCategory } = useToggleCategory();
@@ -67,128 +69,137 @@ const CreatePostPage = () => {
       <div className="flex justify-center px-16 py-10">
         <div className="w-full max-w-5xl px-14">
           <h1 className="text-2xl font-bold mb-6 text-center">밥친구 구하기</h1>
-          <form onSubmit={handleSubmit} className="flex gap-x-8 justify-center">
-            <div className="space-y-4">
-              <FormField
-                label="제목"
-                type="text"
-                value={formData.title}
-                name="title"
-                onChange={handleInputChange}
-                minLength={1}
-                maxLength={60}
-              />
-              <FormField
-                label="모임 날짜"
-                type="datetime-local"
-                value={formData.meetingDateTime}
-                name="meetingDateTime"
-                onChange={handleInputChange}
-                min={getLocalDateTime()}
-                max={getOneYearLaterDateTime()}
-              />
-              <FormField
-                label="모임 인원"
-                type="number"
-                value={formData.maxCount === 0 ? '' : formData.maxCount}
-                name="maxCount"
-                onChange={handleInputChange}
-                min={2}
-                max={99}
-              />
-              <div className="form-control gap-y-4">
-                <div className="label">
-                  <span className="label-text font-bold">장소</span>
-                </div>
-                <input
+          {isPending ? (
+            <div className="flex justify-center items-center w-full h-[70vh]">
+              <LoadingSpinner />
+            </div>
+          ) : (
+            <form
+              onSubmit={handleSubmit}
+              className="flex gap-x-8 justify-center"
+            >
+              <div className="space-y-4">
+                <FormField
+                  label="제목"
                   type="text"
-                  value={selectedPlace?.place_name || ''}
-                  placeholder="장소"
-                  readOnly
-                  className="input input-bordered"
-                />
-                <input
-                  type="text"
-                  value={formData.address}
-                  placeholder="주소"
-                  readOnly
-                  className="input input-bordered"
-                />
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  onClick={openModal}
-                >
-                  모임 장소 찾기
-                </button>
-              </div>
-              <div className="form-control">
-                <div className="label">
-                  <span className="label-text font-bold">카테고리</span>
-                </div>
-                <Categories
-                  selectedCategories={categories}
-                  toggleCategory={toggleCategory}
-                  size="xs"
-                />
-              </div>
-              <label className="form-control">
-                <div className="label">
-                  <span className="label-text font-bold">내용</span>
-                </div>
-                <textarea
-                  className="textarea textarea-bordered max-w-sm text-sm resize-none"
-                  rows={10}
-                  value={formData.content}
-                  name="content"
+                  value={formData.title}
+                  name="title"
                   onChange={handleInputChange}
                   minLength={1}
-                  maxLength={600}
-                  required
+                  maxLength={60}
                 />
-              </label>
-            </div>
-            <div className="flex flex-col justify-between items-center">
-              <label htmlFor="file-upload" className="cursor-pointer">
-                <img
-                  src={thumbnailUrl || 'image/upload_image.webp'}
-                  alt="Thumbnail"
-                  className="w-[280px] h-[178.48px] object-cover rounded-3xl"
+                <FormField
+                  label="모임 날짜"
+                  type="datetime-local"
+                  value={formData.meetingDateTime}
+                  name="meetingDateTime"
+                  onChange={handleInputChange}
+                  min={getLocalDateTime()}
+                  max={getOneYearLaterDateTime()}
                 />
-                <input
-                  id="file-upload"
-                  type="file"
-                  className="hidden"
-                  accept=".jpg,.jpeg,.png"
-                  onChange={handleFileChange}
+                <FormField
+                  label="모임 인원"
+                  type="number"
+                  value={formData.maxCount === 0 ? '' : formData.maxCount}
+                  name="maxCount"
+                  onChange={handleInputChange}
+                  min={2}
+                  max={99}
                 />
-              </label>
-              {selectedPlace && (
-                <div className="mt-4">
-                  <Map
-                    center={{
-                      lat: parseFloat(selectedPlace.y),
-                      lng: parseFloat(selectedPlace.x),
-                    }}
-                    className="w-[320px] h-[320px]"
-                    level={5}
+                <div className="form-control gap-y-4">
+                  <div className="label">
+                    <span className="label-text font-bold">장소</span>
+                  </div>
+                  <input
+                    type="text"
+                    value={selectedPlace?.place_name || ''}
+                    placeholder="장소"
+                    readOnly
+                    className="input input-bordered"
+                  />
+                  <input
+                    type="text"
+                    value={formData.address}
+                    placeholder="주소"
+                    readOnly
+                    className="input input-bordered"
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    onClick={openModal}
                   >
-                    <MapMarker
-                      position={{
+                    모임 장소 찾기
+                  </button>
+                </div>
+                <div className="form-control">
+                  <div className="label">
+                    <span className="label-text font-bold">카테고리</span>
+                  </div>
+                  <Categories
+                    selectedCategories={categories}
+                    toggleCategory={toggleCategory}
+                    size="xs"
+                  />
+                </div>
+                <label className="form-control">
+                  <div className="label">
+                    <span className="label-text font-bold">내용</span>
+                  </div>
+                  <textarea
+                    className="textarea textarea-bordered max-w-sm text-sm resize-none"
+                    rows={10}
+                    value={formData.content}
+                    name="content"
+                    onChange={handleInputChange}
+                    minLength={1}
+                    maxLength={600}
+                    required
+                  />
+                </label>
+              </div>
+              <div className="flex flex-col justify-between items-center">
+                <label htmlFor="file-upload" className="cursor-pointer">
+                  <img
+                    src={thumbnailUrl || 'image/upload_image.webp'}
+                    alt="Thumbnail"
+                    className="w-[280px] h-[178.48px] object-cover rounded-3xl"
+                  />
+                  <input
+                    id="file-upload"
+                    type="file"
+                    className="hidden"
+                    accept=".jpg,.jpeg,.png"
+                    onChange={handleFileChange}
+                  />
+                </label>
+                {selectedPlace && (
+                  <div className="mt-4">
+                    <Map
+                      center={{
                         lat: parseFloat(selectedPlace.y),
                         lng: parseFloat(selectedPlace.x),
                       }}
-                    />
-                  </Map>
+                      className="w-[320px] h-[320px]"
+                      level={5}
+                    >
+                      <MapMarker
+                        position={{
+                          lat: parseFloat(selectedPlace.y),
+                          lng: parseFloat(selectedPlace.x),
+                        }}
+                      />
+                    </Map>
+                  </div>
+                )}
+                <div className="flex justify-end mt-auto ml-auto">
+                  <button type="submit" className="btn btn-primary">
+                    업로드
+                  </button>
                 </div>
-              )}
-              <div className="flex justify-end mt-auto ml-auto">
-                <button type="submit" className="btn btn-primary">
-                  업로드
-                </button>
               </div>
-            </div>
-          </form>
+            </form>
+          )}
         </div>
       </div>
       {isModalOpen && (

--- a/src/types/Meeting.ts
+++ b/src/types/Meeting.ts
@@ -8,7 +8,7 @@ export interface CreateMeetingRequest {
   maxCount: number;
   category: string[];
   content: string;
-  thumbnail?: string;
+  thumbnail?: File | null;
 }
 
 export interface CreateMeetingResponse extends CreateMeetingRequest {


### PR DESCRIPTION
## 📌 관련 이슈
- close #179 

## 📝 변경 사항
### AS-IS
- 썸네일 이미지 형식 제한 X
- thumbnail: string으로 전달. 
- 모집글 생성 기능 요청값이 json 객체

### TO-BE
- 썸네일 이미지는 jpg, jpeg, png 형식의 파일만 가능하다.
- thumbnail: string이 아닌 File 형식으로 전달하다.
- 모집글 생성 기능에 전달하는 데이터는 formdata이다.
- isPending으로 데이터 요청 상태를 처리한다.
- thumbnail과 thumbnailUrl을 분리, thumbnail은 File 형식, thumbnailUrl은 미리보기 가능하도록 URL.createObjectURL로 구현

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게

