### PR TITLE
✨ [Feat] 신청한 모집글 상세 페이지에서 버튼 렌더링 구현(신청자 입장)

### DIFF
--- a/src/api/meeting.ts
+++ b/src/api/meeting.ts
@@ -32,7 +32,7 @@ export const searchMeetings = async (params: SearchMeetingsRequest) =>
 export const setMeetingStatus = async (id: string, data: MeetingStatus) =>
   apiClient({ url: `${COMMON_URL}/${id}`, method: 'patch', data });
 
-export const getParticipants = async (id: string) =>
+export const getParticipants = async (id: number) =>
   apiClient({ url: `${COMMON_URL}/${id}/participants`, method: 'get' });
 
 export const getMyMeetings = async (params: getMyMeetingsRequest) =>

--- a/src/api/paricipations.ts
+++ b/src/api/paricipations.ts
@@ -36,7 +36,7 @@ export const rejectParticipation = async (participationId: number) => {
 // 모임 참여 삭제 & 취소
 export const deleteParticipation = async (participationId: number) => {
   return apiClient({
-    url: `${COMMON_URL}/${{ participationId }}`,
+    url: `${COMMON_URL}/${participationId}`,
     method: 'delete',
   });
 };

--- a/src/components/DetailPageLayout.tsx
+++ b/src/components/DetailPageLayout.tsx
@@ -18,7 +18,7 @@ const DetailPageLayout = ({
   return (
     <div className="flex justify-center px-16 py-10">
       <div className="w-full max-w-5xl px-14">
-        <h1 className="text-2xl font-bold mb-6 text-center mb-10">
+        <h1 className="text-2xl font-bold text-center mb-10">
           {meeting.title}
         </h1>
         <div className="flex gap-x-8 justify-center">

--- a/src/components/MyPage/ParticipantList.tsx
+++ b/src/components/MyPage/ParticipantList.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-// import { useGetParticipants } from '../../hooks/useGetParticipants';
-import { users } from '../../mocks/users';
+import { useGetParticipants } from '../../hooks/useGetParticipants';
 import { Post } from '../../types/Post';
-import { User } from '../../types/User';
+import { Participants } from '../../types/User';
 
 const ParticipantList = ({
   post,
@@ -12,45 +10,45 @@ const ParticipantList = ({
   post: Post;
   isFinished: boolean;
 }) => {
-  // TODO : renderUserList 리팩토링 필요
-  // const { data: users, isLoading, isError } = useGetParticipants(post.id || '');
+  const { data: users } = useGetParticipants(post.id);
 
-  // const pendingUsers =
-  //   users?.filter(user => user.participationStatus === 'pending') || [];
+  const pendingUsers =
+    users?.filter(user => user.participationStatus === 'pending') || [];
 
-  // const approvedUsers =
-  //   users?.filter(user => user.participationStatus === 'approved') || [];
-
-  const [participants, setParticipants] = useState(users);
-
-  useEffect(() => {
-    if (post.participatedUserId) {
-      const filteredParticipants = users.filter(user =>
-        post.participatedUserId?.includes(user.userId)
-      );
-      setParticipants(filteredParticipants);
-    }
-  }, [post.participatedUserId]);
-
-  const { pendingUsers, approvedUsers } = participants.reduce(
-    (acc: { pendingUsers: User[]; approvedUsers: User[] }, participant) => {
-      if (participant.status === 'pending') {
-        acc.pendingUsers.push(participant);
-      } else if (participant.status === 'approved') {
-        acc.approvedUsers.push(participant);
-      }
-      return acc;
-    },
-    { pendingUsers: [], approvedUsers: [] }
-  );
+  const approvedUsers =
+    users?.filter(user => user.participationStatus === 'approved') || [];
 
   const navigate = useNavigate();
 
-  const handleGoToProfile = (participantId: string, status: string) => {
+  const handleGoToProfile = (participantId: number, status: string) => {
     navigate(`/view-applicant/profile/${participantId}?status=${status}`);
   };
 
-  const renderUserList = (users: User[], title: string) => (
+  // 목데이터용 코드
+  // const [participants, setParticipants] = useState(users);
+
+  // useEffect(() => {
+  //   if (post.participatedUserId) {
+  //     const filteredParticipants = users.filter(user =>
+  //       post.participatedUserId?.includes(user.userId)
+  //     );
+  //     setParticipants(filteredParticipants);
+  //   }
+  // }, [post.participatedUserId]);
+
+  // const { pendingUsers, approvedUsers } = participants.reduce(
+  //   (acc: { pendingUsers: User[]; approvedUsers: User[] }, participant) => {
+  //     if (participant.status === 'pending') {
+  //       acc.pendingUsers.push(participant);
+  //     } else if (participant.status === 'approved') {
+  //       acc.approvedUsers.push(participant);
+  //     }
+  //     return acc;
+  //   },
+  //   { pendingUsers: [], approvedUsers: [] }
+  // );
+
+  const renderUserList = (users: Participants[], title: string) => (
     <div className="mb-4">
       <span className="block text-lg font-extrabold mb-3 cursor-default">
         {title}
@@ -62,7 +60,10 @@ const ParticipantList = ({
               key={index}
               className="p-2 flex items-center gap-2 border-gray-300 border-[1px] rounded-xl cursor-pointer transform transition-all duration-300 ease-in-out hover:translate-y-[-4px]"
               onClick={() =>
-                handleGoToProfile(participant.userId, participant.status)
+                handleGoToProfile(
+                  participant.userId,
+                  participant.participationStatus
+                )
               }
             >
               <img
@@ -84,7 +85,7 @@ const ParticipantList = ({
   );
 
   return (
-    <div className="min-w-[340px] md:min-w-96 flex flex-col gap-3 h-full pt-10">
+    <div className="min-w-[340px] md:min-w-96 flex flex-col gap-3 h-full pt-20">
       {!isFinished && renderUserList(pendingUsers, '참여 신청')}
       {renderUserList(approvedUsers, '참여 확정')}
     </div>

--- a/src/components/MyPage/ParticipatedMeetings.tsx
+++ b/src/components/MyPage/ParticipatedMeetings.tsx
@@ -9,7 +9,7 @@ const ParticipatedMeetings = () => {
 
   if (data === undefined) return;
 
-  const posts = data.appliedMeetings;
+  const posts = data.allData.appliedMeetings;
 
   return (
     <div className="px-16 py-1">

--- a/src/hooks/useDeleteParticipation.ts
+++ b/src/hooks/useDeleteParticipation.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import { deleteParticipation } from '../api/paricipations';
+
+const useDeleteParticipation = (id: number) => {
+  return useMutation({
+    mutationFn: () => deleteParticipation(id),
+    onSuccess: () => {
+      alert('신청이 취소되었습니다.');
+    },
+    onError: error => {
+      if (axios.isAxiosError(error)) {
+        console.log(error);
+        alert(error.message);
+      } else {
+        console.log(error);
+        alert('알 수 없는 오류가 발생했습니다.');
+      }
+    },
+  });
+};
+
+export default useDeleteParticipation;

--- a/src/hooks/useGetMyParticipatedMeetings.ts
+++ b/src/hooks/useGetMyParticipatedMeetings.ts
@@ -9,6 +9,10 @@ const useGetMyParticipatedMeetings = (
     queryKey: ['get-participated-meetings', params],
     queryFn: () => getParticipatedMeetings(params),
     retry: false,
+    select: data => {
+      const meetingIds = data.appliedMeetings.map(meeting => meeting.meetingId);
+      return { meetingIds, allData: data };
+    },
   });
 };
 

--- a/src/hooks/useGetParticipants.ts
+++ b/src/hooks/useGetParticipants.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getParticipants } from '../api/meeting';
 import type { Participants } from '../types/User';
 
-export function useGetParticipants(id: string) {
+export function useGetParticipants(id: number) {
   return useQuery<Participants[]>({
     queryKey: ['participants', id],
     queryFn: () => getParticipants(id),

--- a/src/pages/ApplyMeetingPage.tsx
+++ b/src/pages/ApplyMeetingPage.tsx
@@ -7,8 +7,7 @@ import { Post } from '../types/Post';
 const ApplyMeetingPage = ({ meeting }: { meeting: Post }) => {
   const { data } = useGetMyParticipatedMeetings({});
   const appliedMeetingIds = data?.meetingIds;
-  let hasApplied = false;
-  if (appliedMeetingIds?.includes(meeting.id)) hasApplied = true;
+  const hasApplied = !!appliedMeetingIds?.includes(meeting.id);
 
   const { mutate: participateMeeting } = useParticipateMeeting(meeting.id);
   const { mutate: cancelParticipation } = useDeleteParticipation(

--- a/src/pages/ApplyMeetingPage.tsx
+++ b/src/pages/ApplyMeetingPage.tsx
@@ -1,4 +1,5 @@
 import DetailPageLayout from '../components/DetailPageLayout';
+import useDeleteParticipation from '../hooks/useDeleteParticipation';
 import useGetMyParticipatedMeetings from '../hooks/useGetMyParticipatedMeetings';
 import useParticipateMeeting from '../hooks/useParticipateMeeting';
 import { Post } from '../types/Post';
@@ -10,8 +11,13 @@ const ApplyMeetingPage = ({ meeting }: { meeting: Post }) => {
   if (appliedMeetingIds?.includes(meeting.id)) hasApplied = true;
 
   const { mutate: participateMeeting } = useParticipateMeeting(meeting.id);
+  const { mutate: cancelParticipation } = useDeleteParticipation(
+    Number(localStorage.getItem('userId'))
+  );
 
-  const handleClick = () => {};
+  const handleCancelParticipation = () => {
+    cancelParticipation();
+  };
 
   const handleParticipate = () => {
     participateMeeting();
@@ -21,7 +27,7 @@ const ApplyMeetingPage = ({ meeting }: { meeting: Post }) => {
     <DetailPageLayout
       meeting={meeting}
       buttonLabel={hasApplied ? '신청취소' : '신청'}
-      onClick={hasApplied ? handleClick : handleParticipate}
+      onClick={hasApplied ? handleCancelParticipation : handleParticipate}
     />
   );
 };

--- a/src/pages/ApplyMeetingPage.tsx
+++ b/src/pages/ApplyMeetingPage.tsx
@@ -1,10 +1,16 @@
 import DetailPageLayout from '../components/DetailPageLayout';
+import useGetMyParticipatedMeetings from '../hooks/useGetMyParticipatedMeetings';
 import useParticipateMeeting from '../hooks/useParticipateMeeting';
 import { Post } from '../types/Post';
 
 const ApplyMeetingPage = ({ meeting }: { meeting: Post }) => {
-  const hasApplied = false; // TODO: 참여신청한 목록 조회에서 반환하는 meetingId로 처리해야할 것 같습니다.
+  const { data } = useGetMyParticipatedMeetings({});
+  const appliedMeetingIds = data?.meetingIds;
+  let hasApplied = false;
+  if (appliedMeetingIds?.includes(meeting.id)) hasApplied = true;
+
   const { mutate: participateMeeting } = useParticipateMeeting(meeting.id);
+
   const handleClick = () => {};
 
   const handleParticipate = () => {

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -287,13 +287,6 @@ const PostEditPage = ({
                   onChange={handleFileChange}
                 />
               </label>
-              {/* <div>
-                <img
-                  src={meeting.thumbnail || 'image/upload_image.webp'}
-                  alt="Thumbnail"
-                  className="w-[280px] h-[178.48px] object-cover rounded-3xl"
-                />
-              </div> */}
               <div className="mt-4">
                 <Map
                   center={{

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../utils/getLocalDateTime';
 import { categoryValueToKey } from '../utils/categoryValueToKey';
 import { UseQueryResult } from '@tanstack/react-query';
+import LoadingSpinner from '../components/LoadingSpinner';
 
 const PostEditPage = ({
   meeting,
@@ -22,7 +23,7 @@ const PostEditPage = ({
   refetch: UseQueryResult['refetch'];
 }) => {
   const id = meeting.id;
-  const { mutate: editMeeting } = useEditMeeting();
+  const { mutate: editMeeting, isPending } = useEditMeeting();
   const [isEditMode, setIsEditMode] = useState(false);
   const [editData, setEditData] = useState<CreateMeetingRequest>();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -30,7 +31,7 @@ const PostEditPage = ({
   const token = localStorage.getItem('accessToken');
   const [thumbnail, setThumbnail] = useState<File | null>(null);
   const [thumbnailUrl, setThumbnailUrl] = useState<string>(
-    '/image/thumbnail_default.webp'
+    meeting.thumbnail || '/image/thumbnail_default.webp'
   );
 
   useEffect(() => {
@@ -183,6 +184,13 @@ const PostEditPage = ({
     );
   }
 
+  if (isPending)
+    return (
+      <div className="w-full h-screen flex justify-center items-center">
+        <LoadingSpinner />
+      </div>
+    );
+
   return (
     <>
       <div className="flex justify-center px-16 py-10">
@@ -267,7 +275,7 @@ const PostEditPage = ({
             <div className="flex flex-col justify-between">
               <label htmlFor="file-upload" className="cursor-pointer">
                 <img
-                  src={meeting.thumbnail || thumbnailUrl}
+                  src={thumbnailUrl || meeting.thumbnail}
                   alt="Thumbnail"
                   className="w-[280px] h-[178.48px] object-cover rounded-3xl"
                 />

--- a/src/pages/ViewParticipantPage.tsx
+++ b/src/pages/ViewParticipantPage.tsx
@@ -52,10 +52,10 @@ const ViewParticipantPage = () => {
               />
             </div>
             {!isFinished && (
-              <div className="w-full flex items-center gap-3 mt-4">
+              <div className="w-full flex items-center gap-3 mt-4 px-5">
                 <button
                   type="button"
-                  className="btn btn-primary flex-1 transform transition-all duration-300 ease-in-out hover:translate-y-[-4px]"
+                  className="btn btn-second flex-1 transform transition-all duration-300 ease-in-out hover:translate-y-[-4px]"
                   onClick={handleCloseMeeting}
                 >
                   모집 완료


### PR DESCRIPTION
## 📌 관련 이슈
- close #210 

## 📝 변경 사항
### AS-IS
- hasApplied 값을 하드코딩하여 신청자 입장 상세페이지 버튼 렌더링 구현(신청 취소 버튼 렌더링 구현x)

### TO-BE
- 신청한 모집글 조회 API에서 meetingId 배열을 반환(useQuery의 select 사용)
- 신청한 meetingId에 해당 모집글의 id가 포함되어 있으면 hasApplied를 true로 주어 렌더링 조건으로 사용
- 신청한 모집글은 신청 취소 버튼 렌더링
- 신청 취소 API 연동

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
