### PR TITLE
♻️ [Refactor] 신청 취소 API participationId 값 수정

### DIFF
--- a/src/hooks/useDeleteParticipation.ts
+++ b/src/hooks/useDeleteParticipation.ts
@@ -7,6 +7,7 @@ const useDeleteParticipation = (id: number) => {
     mutationFn: () => deleteParticipation(id),
     onSuccess: () => {
       alert('신청이 취소되었습니다.');
+      // window.location.reload();
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/hooks/useDeleteParticipation.ts
+++ b/src/hooks/useDeleteParticipation.ts
@@ -7,7 +7,6 @@ const useDeleteParticipation = (id: number) => {
     mutationFn: () => deleteParticipation(id),
     onSuccess: () => {
       alert('신청이 취소되었습니다.');
-      // window.location.reload();
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/hooks/useGetMyParticipatedMeetings.ts
+++ b/src/hooks/useGetMyParticipatedMeetings.ts
@@ -11,7 +11,9 @@ const useGetMyParticipatedMeetings = (
     retry: false,
     select: data => {
       const meetingIds = data.appliedMeetings.map(meeting => meeting.meetingId);
-      const participationIds = data.appliedMeetings.map(meeting => meeting.id);
+      const participationIds = data.appliedMeetings.map(
+        meeting => meeting.participationId
+      );
       return { meetingIds, participationIds, allData: data };
     },
   });

--- a/src/hooks/useGetMyParticipatedMeetings.ts
+++ b/src/hooks/useGetMyParticipatedMeetings.ts
@@ -11,7 +11,8 @@ const useGetMyParticipatedMeetings = (
     retry: false,
     select: data => {
       const meetingIds = data.appliedMeetings.map(meeting => meeting.meetingId);
-      return { meetingIds, allData: data };
+      const participationIds = data.appliedMeetings.map(meeting => meeting.id);
+      return { meetingIds, participationIds, allData: data };
     },
   });
 };

--- a/src/hooks/useParticipateMeeting.ts
+++ b/src/hooks/useParticipateMeeting.ts
@@ -12,7 +12,6 @@ const useParticipateMeeting = (meetingId: number) => {
     },
     onSuccess: () => {
       alert('신청이 완료되었습니다.');
-      // window.location.reload();
     },
     onError: error => {
       if (error instanceof AxiosError) {

--- a/src/hooks/useParticipateMeeting.ts
+++ b/src/hooks/useParticipateMeeting.ts
@@ -1,11 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import axiosInstance from '../api/axiosInstance';
 
 const useParticipateMeeting = (meetingId: number) => {
-  const navigate = useNavigate();
-
   return useMutation({
     mutationFn: async () => {
       const response = await axiosInstance.post(
@@ -15,7 +12,7 @@ const useParticipateMeeting = (meetingId: number) => {
     },
     onSuccess: () => {
       alert('신청이 완료되었습니다.');
-      navigate(`/post/${meetingId}`);
+      // window.location.reload();
     },
     onError: error => {
       if (error instanceof AxiosError) {

--- a/src/types/Meeting.ts
+++ b/src/types/Meeting.ts
@@ -50,7 +50,7 @@ export interface getParticipatedMeetingsRequest {
 }
 
 export interface ParticipantsResponse {
-  id: number;
+  participationId: number;
   meetingId: number;
   authorId: number;
   participationStatus:


### PR DESCRIPTION
## 📌 관련 이슈
- close #214 

## 📝 변경 사항
### AS-IS
- 신청취소 API 참여자 id 전달

### TO-BE
- participatingId(신청한 모임의 id)를 계산하는 로직을 추가
- refetch를 활용해 데이터를 다시 불러올 때 hasApplied 상태 변경


## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게

