### PR TITLE
✨ [Feat] 모임 삭제 & 모임 상태 변경(모집 완료) 구현

### DIFF
--- a/src/components/PostCardBtn.tsx
+++ b/src/components/PostCardBtn.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { CreatedMeeting, ParticipantsResponse } from '../types/Meeting';
+import useDeleteMeeting from '../hooks/useDeleteMeeting';
 
 interface PostCardBtnProps {
   post: CreatedMeeting | ParticipantsResponse;
@@ -14,6 +15,7 @@ const PostCardBtn: React.FC<PostCardBtnProps> = ({
   status,
 }) => {
   const navigate = useNavigate();
+  const { mutate: deleteMeeting } = useDeleteMeeting();
 
   const handleGoToPostBtnClick = () => {
     navigate(`/post/${post.meetingId}`);
@@ -23,14 +25,19 @@ const PostCardBtn: React.FC<PostCardBtnProps> = ({
     navigate(`/view-applicant/${post.meetingId}?status=${status}`);
   };
 
+  const handleDeleteMeetingBtnClick = () => {
+    deleteMeeting(post.meetingId.toString());
+  };
+
   const handleDeleteBtnClick = () => {
-    // TODO: API 참가한 모임 목록에서 DELETE 요청
+    // TODO: API 참가한 모임 목록에서 DELETE 요청(신청자 입장)
   };
 
   const isAvailableDelete =
     status === '승인 거부' || status === '모집 취소' || status === '모집 완료';
 
   const isAvailableViewPost = status === 'RECRUITING';
+  const isAbailableDelete = status === 'CLOSED';
 
   return (
     <>
@@ -49,13 +56,23 @@ const PostCardBtn: React.FC<PostCardBtnProps> = ({
           ) : (
             <div className="flex-1" />
           )}
-          <button
-            type="button"
-            onClick={() => handleAdminBtnClick()}
-            className="btn btn-second btn-sm font-bold flex-1"
-          >
-            신청자 보기
-          </button>
+          {isAbailableDelete ? (
+            <button
+              type="button"
+              onClick={() => handleDeleteMeetingBtnClick()}
+              className="btn btn-second btn-sm font-bold flex-1"
+            >
+              모임 삭제
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => handleAdminBtnClick()}
+              className="btn btn-second btn-sm font-bold flex-1"
+            >
+              신청자 보기
+            </button>
+          )}
         </div>
       )}
       {isParticipated && (

--- a/src/hooks/useCloseMeeting.ts
+++ b/src/hooks/useCloseMeeting.ts
@@ -1,14 +1,17 @@
 import { useMutation } from '@tanstack/react-query';
 import { setMeetingStatus } from '../api/meeting';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 export function useCloseMeeting() {
+  const navigate = useNavigate();
   return useMutation({
     mutationFn: async (id: string) => {
-      await setMeetingStatus(id, { status: 'CLOSED' });
+      await setMeetingStatus(id, { meetingStatus: 'CLOSED' });
     },
     onSuccess: () => {
       alert('모집완료 되었습니다.');
+      navigate('/mypage/my-meetings', { replace: true });
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/hooks/useDeleteMeeting.ts
+++ b/src/hooks/useDeleteMeeting.ts
@@ -1,12 +1,18 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { deleteMeeting } from '../api/meeting';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const useDeleteMeeting = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
   return useMutation({
     mutationFn: (id: string) => deleteMeeting(id),
     onSuccess: () => {
       alert('모임이 취소되었습니다.');
+      if (location.pathname === '/view-applicant')
+        navigate('/mypage/my-meetings', { replace: true });
+      else navigate('/mypage/my-meetings', { state: { key: Date.now() } });
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import Layout from '../components/Layout/Layout';
 import AccountDeletion from '../components/MyPage/AccountDeletion';
 import MyMeetings from '../components/MyPage/MyMeetings';
@@ -22,6 +22,7 @@ import KakaoLogin from '../components/Login/KakaoLogin';
 import ProtectedRoute from '../components/ProtectedRoute/ProtectedRoute';
 
 const Router = () => {
+  const location = useLocation();
   return (
     <QueryClientProvider client={queryClient}>
       <Routes>
@@ -66,7 +67,10 @@ const Router = () => {
             }
           >
             <Route path="my-profile" element={<MyProfile />} />
-            <Route path="my-meetings" element={<MyMeetings />} />
+            <Route
+              path="my-meetings"
+              element={<MyMeetings key={location.state?.key} />}
+            />
             <Route path="account-deletion" element={<AccountDeletion />} />
           </Route>
           {/* 주최한 모임 -> 신청자 보기 페이지 */}

--- a/src/types/Meeting.ts
+++ b/src/types/Meeting.ts
@@ -36,7 +36,7 @@ export interface SearchMeetingsRequest {
 }
 
 export interface MeetingStatus {
-  status: 'RECRUITING' | 'CLOSED';
+  meetingStatus: 'RECRUITING' | 'CLOSED';
 }
 
 export interface getMyMeetingsRequest {


### PR DESCRIPTION
## 📌 관련 이슈
- close #228 

## 📝 변경 사항
- 모집 완료 버튼 클릭시 모임 상태 변경 API를 호출하여 "CLOSED" 상태로 변경
- 모임 삭제 API 호출 후 리다이렉트 추가
  - 신청자 보기 페이지에서 모집 취소를 누르면 모임이 삭제되고 "마이페이지 - 내 모임"으로 이동
  - 모집 완료 후 주최한 모임 목록에서 모임 삭제 버튼을 누르면 모임이 삭제되고 해당 페이지 재마운트

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
1.
<img width="822" alt="스크린샷 2025-02-05 오전 12 24 07" src="https://github.com/user-attachments/assets/9716b695-fe12-4166-afa6-39308fcae480" />

2.
<img width="663" alt="스크린샷 2025-02-05 오전 12 24 44" src="https://github.com/user-attachments/assets/4fd73f94-8430-4d12-bd00-a284d895d0ce" />



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

