### PR TITLE
♻️ [Refactor] 모임 취소 API 호출 성공시 페이지 재렌더링 리팩토링

### DIFF
--- a/src/components/MyPage/ParticipantList.tsx
+++ b/src/components/MyPage/ParticipantList.tsx
@@ -24,7 +24,7 @@ const ParticipantList = ({
     status: string
   ) => {
     navigate(
-      `/view-applicant/profile/${participantId}/${userId}?status=${status}`
+      `/view-applicant/profile/${participantId}/${userId}/${post.id}?status=${status}`
     );
   };
 

--- a/src/components/UserProfileBtn.tsx
+++ b/src/components/UserProfileBtn.tsx
@@ -14,8 +14,8 @@ const UserProfileBtn = ({
   roomId: number;
   participationId: number;
 }) => {
-  const { mutate: approveParticipation } = useApproveParticipation();
-  const { mutate: rejectParticipation } = useRejectParticipation();
+  const { mutate: approveParticipation } = useApproveParticipation(roomId);
+  const { mutate: rejectParticipation } = useRejectParticipation(roomId);
   const setIsViewParticipantListOpen = useSetRecoilState(
     isViewParticipantListOpenState
   );
@@ -31,7 +31,6 @@ const UserProfileBtn = ({
   const handleApproveUser = () => {
     try {
       approveParticipation(participationId);
-      navigate(-1);
     } catch (error) {
       console.log(error);
     }

--- a/src/hooks/useApproveParticipation.ts
+++ b/src/hooks/useApproveParticipation.ts
@@ -3,14 +3,14 @@ import axios from 'axios';
 import { approveParticipation } from '../api/paricipations';
 import { useNavigate } from 'react-router-dom';
 
-export const useApproveParticipation = () => {
+export const useApproveParticipation = (roomId: number) => {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: (participationId: number) =>
       approveParticipation(participationId),
     onSuccess: () => {
       alert('신청을 승인하였습니다.');
-      navigate(-1);
+      navigate(`/view-applicant/${roomId}`, { replace: true });
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/hooks/useDeleteMeeting.ts
+++ b/src/hooks/useDeleteMeeting.ts
@@ -1,9 +1,10 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { deleteMeeting } from '../api/meeting';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const useDeleteMeeting = () => {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
   return useMutation({
@@ -12,7 +13,7 @@ const useDeleteMeeting = () => {
       alert('모임이 취소되었습니다.');
       if (location.pathname === '/view-applicant')
         navigate('/mypage/my-meetings', { replace: true });
-      else navigate('/mypage/my-meetings', { state: { key: Date.now() } });
+      else queryClient.invalidateQueries({ queryKey: ['get-my-meetings'] });
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/hooks/useGetParticipants.ts
+++ b/src/hooks/useGetParticipants.ts
@@ -4,7 +4,7 @@ import type { Participants } from '../types/User';
 
 export function useGetParticipants(id: number) {
   return useQuery<Participants[]>({
-    queryKey: ['participants', id],
+    queryKey: ['get-participants', id],
     queryFn: () => getParticipants(id),
     enabled: !!id,
     refetchOnWindowFocus: false,

--- a/src/hooks/useRejectParticipation.ts
+++ b/src/hooks/useRejectParticipation.ts
@@ -3,14 +3,14 @@ import axios from 'axios';
 import { rejectParticipation } from '../api/paricipations';
 import { useNavigate } from 'react-router-dom';
 
-export const useRejectParticipation = () => {
+export const useRejectParticipation = (roomId: number) => {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: (participationId: number) =>
       rejectParticipation(participationId),
     onSuccess: () => {
       alert('신청을 거절하였습니다.');
-      navigate(-1);
+      navigate(`/view-applicant/${roomId}`, { replace: true });
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import Layout from '../components/Layout/Layout';
 import AccountDeletion from '../components/MyPage/AccountDeletion';
 import MyMeetings from '../components/MyPage/MyMeetings';
@@ -22,7 +22,6 @@ import KakaoLogin from '../components/Login/KakaoLogin';
 import ProtectedRoute from '../components/ProtectedRoute/ProtectedRoute';
 
 const Router = () => {
-  const location = useLocation();
   return (
     <QueryClientProvider client={queryClient}>
       <Routes>
@@ -67,10 +66,7 @@ const Router = () => {
             }
           >
             <Route path="my-profile" element={<MyProfile />} />
-            <Route
-              path="my-meetings"
-              element={<MyMeetings key={location.state?.key} />}
-            />
+            <Route path="my-meetings" element={<MyMeetings />} />
             <Route path="account-deletion" element={<AccountDeletion />} />
           </Route>
           {/* 주최한 모임 -> 신청자 보기 페이지 */}

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -82,7 +82,7 @@ const Router = () => {
           {/* 주최한 모임 -> 신청자 보기 페이지 -> 신청자 프로필 보기 */}
 
           <Route
-            path="/view-applicant/profile/:participationId/:userId"
+            path="/view-applicant/profile/:participationId/:userId/:roomId"
             element={
               <ProtectedRoute>
                 <UserProfilePage />


### PR DESCRIPTION
## 📌 관련 이슈
- close #236 

## 📝 변경 사항
### AS-IS
- 임의로 라우터에서 컴포넌트에 key값을 주어 모임 취소 API 호출 성공시 임의의 값을 key값으로 갱신하여 해당 컴포넌트가 리렌더링 되도록 함

### TO-BE
- tanstackQuery의 invalidateQueries 메서드를 사용하여 캐싱을 무효화하고 주최한 모임 목록 API를 refetch할 수 있도록 리팩토링

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
