### PR TITLE
♻️ [Refactor] 참여 승인 / 거절 API 호출 성공 이벤트 처리 개선

### DIFF
--- a/src/components/MyPage/ParticipantList.tsx
+++ b/src/components/MyPage/ParticipantList.tsx
@@ -24,7 +24,7 @@ const ParticipantList = ({
     status: string
   ) => {
     navigate(
-      `/view-applicant/profile/${participantId}/${userId}?status=${status}`
+      `/view-applicant/profile/${participantId}/${userId}/${post.id}?status=${status}`
     );
   };
 

--- a/src/components/UserProfileBtn.tsx
+++ b/src/components/UserProfileBtn.tsx
@@ -14,8 +14,8 @@ const UserProfileBtn = ({
   roomId: number;
   participationId: number;
 }) => {
-  const { mutate: approveParticipation } = useApproveParticipation();
-  const { mutate: rejectParticipation } = useRejectParticipation();
+  const { mutate: approveParticipation } = useApproveParticipation(roomId);
+  const { mutate: rejectParticipation } = useRejectParticipation(roomId);
   const setIsViewParticipantListOpen = useSetRecoilState(
     isViewParticipantListOpenState
   );
@@ -31,7 +31,6 @@ const UserProfileBtn = ({
   const handleApproveUser = () => {
     try {
       approveParticipation(participationId);
-      navigate(-1);
     } catch (error) {
       console.log(error);
     }

--- a/src/hooks/useApproveParticipation.ts
+++ b/src/hooks/useApproveParticipation.ts
@@ -1,17 +1,15 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { approveParticipation } from '../api/paricipations';
 import { useNavigate } from 'react-router-dom';
 
 export const useApproveParticipation = (roomId: number) => {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (participationId: number) =>
       approveParticipation(participationId),
     onSuccess: () => {
       alert('신청을 승인하였습니다.');
-      queryClient.invalidateQueries({ queryKey: ['get-participants'] });
       navigate(`/view-applicant/${roomId}`, { replace: true });
     },
     onError: error => {

--- a/src/hooks/useApproveParticipation.ts
+++ b/src/hooks/useApproveParticipation.ts
@@ -1,16 +1,18 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { approveParticipation } from '../api/paricipations';
 import { useNavigate } from 'react-router-dom';
 
-export const useApproveParticipation = () => {
+export const useApproveParticipation = (roomId: number) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (participationId: number) =>
       approveParticipation(participationId),
     onSuccess: () => {
       alert('신청을 승인하였습니다.');
-      navigate(-1);
+      queryClient.invalidateQueries({ queryKey: ['get-participants'] });
+      navigate(`/view-applicant/${roomId}`, { replace: true });
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/hooks/useGetParticipants.ts
+++ b/src/hooks/useGetParticipants.ts
@@ -4,7 +4,7 @@ import type { Participants } from '../types/User';
 
 export function useGetParticipants(id: number) {
   return useQuery<Participants[]>({
-    queryKey: ['participants', id],
+    queryKey: ['get-participants', id],
     queryFn: () => getParticipants(id),
     enabled: !!id,
     refetchOnWindowFocus: false,

--- a/src/hooks/useRejectParticipation.ts
+++ b/src/hooks/useRejectParticipation.ts
@@ -1,16 +1,18 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { rejectParticipation } from '../api/paricipations';
 import { useNavigate } from 'react-router-dom';
 
-export const useRejectParticipation = () => {
+export const useRejectParticipation = (roomId: number) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (participationId: number) =>
       rejectParticipation(participationId),
     onSuccess: () => {
       alert('신청을 거절하였습니다.');
-      navigate(-1);
+      queryClient.invalidateQueries({ queryKey: ['get-participants'] });
+      navigate(`/view-applicant/${roomId}`, { replace: true });
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/hooks/useRejectParticipation.ts
+++ b/src/hooks/useRejectParticipation.ts
@@ -1,17 +1,15 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { rejectParticipation } from '../api/paricipations';
 import { useNavigate } from 'react-router-dom';
 
 export const useRejectParticipation = (roomId: number) => {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (participationId: number) =>
       rejectParticipation(participationId),
     onSuccess: () => {
       alert('신청을 거절하였습니다.');
-      queryClient.invalidateQueries({ queryKey: ['get-participants'] });
       navigate(`/view-applicant/${roomId}`, { replace: true });
     },
     onError: error => {

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -82,7 +82,7 @@ const Router = () => {
           {/* 주최한 모임 -> 신청자 보기 페이지 -> 신청자 프로필 보기 */}
 
           <Route
-            path="/view-applicant/profile/:participationId/:userId"
+            path="/view-applicant/profile/:participationId/:userId/:roomId"
             element={
               <ProtectedRoute>
                 <UserProfilePage />


### PR DESCRIPTION
## 📌 관련 이슈
- close #238 

## 📝 변경 사항
### AS-IS
- 호출 성공 시 단순히 뒤로가기(스택에 남아있어서 앞으로 갈 수 있음)

### TO-BE
- 해당 페이지로 리다이렉트 하도록 처리(스택에서 삭제되도록 옵션값 전달)

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

