### PR TITLE
🐛 Fix: 카테고리 필수입력 처리

### DIFF
--- a/src/hooks/useCreatePostForm.ts
+++ b/src/hooks/useCreatePostForm.ts
@@ -25,6 +25,11 @@ const useCreatePostForm = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
+    if (formData.category.length === 0) {
+      alert('카테고리를 선택해주세요');
+      return;
+    }
+
     const postFormData = new FormData();
     postFormData.append(
       'request',

--- a/src/pages/CreatePostPage.tsx
+++ b/src/pages/CreatePostPage.tsx
@@ -32,6 +32,7 @@ const CreatePostPage = () => {
       category => categoryValueToKey[category]
     );
     updateCategories(mappedCategories);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [categories]);
 
   const [isModalOpen, setIsModalOpen] = useState(false);


### PR DESCRIPTION
## 📌 관련 이슈
- close #241

## 📝 변경 사항
### AS-IS
- 게시물 생성 시 카테고리를 선택하지 않고 업로드 요청이 허용됨
- 필수입력값인 카테고리가 없는 상태로 API요청이 이루어져 에러 발생

### TO-BE
- 카테고리를 선택하지 않은 경우 API요청을 하지 않고 alert 창 띄우기

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/fe4e6c7a-9bd5-474e-b5ab-9317030c4128)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 별개로 useEffect의 린트경고무시 주석 추가했습니다