### PR TITLE
🐛 Fix: 비로그인시 유저정보 API 호출 비활성화

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,21 +3,15 @@ import { FaBell } from 'react-icons/fa6';
 import { Link, useNavigate } from 'react-router-dom';
 import axiosInstance from '../../api/axiosInstance';
 import logo from '../../assets/svg/logo.svg';
-import useNotifications from '../../hooks/useNotifications';
 import useFetchUserProfile from '../../hooks/useFetchUserProfile';
-import { useEffect } from 'react';
+import useNotifications from '../../hooks/useNotifications';
+import LoadingSpinner from '../LoadingSpinner';
 
 const Header = () => {
-  const { data: userProfileData, refetch } = useFetchUserProfile();
+  const { data: userProfileData } = useFetchUserProfile();
   const profileImageUrl = userProfileData?.profileImage;
   const navigate = useNavigate();
   const accessToken = localStorage.getItem('accessToken');
-
-  useEffect(() => {
-    if (accessToken) {
-      refetch();
-    }
-  }, [accessToken, refetch]);
 
   const handleNavigateMypage = () => {
     navigate('/mypage/my-profile');
@@ -51,7 +45,7 @@ const Header = () => {
   if (isLogoutPending) {
     return (
       <div className="w-full h-screen flex justify-center items-center">
-        <span className="loading loading-spinner w-16 text-gray-600"></span>
+        <LoadingSpinner />
       </div>
     );
   }

--- a/src/hooks/useFetchUserProfile.ts
+++ b/src/hooks/useFetchUserProfile.ts
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import fetchUserProfile from '../api/fetchUserProfile';
 
 const useFetchUserProfile = () => {
+  const accessToken = localStorage.getItem('accessToken');
+
   return useQuery({
     queryKey: ['UserProfile'],
     queryFn: fetchUserProfile,
@@ -9,7 +11,7 @@ const useFetchUserProfile = () => {
       const profileImage = data.profileImageUrl;
       return { profileImage, allData: data };
     },
-    retry: false,
+    enabled: accessToken !== null,
   });
 };
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #243 

## 📝 변경 사항
### AS-IS
- 비로그인 상태에서 useFetchUserProfile 을 호출

### TO-BE
- accessToken이 존재할때만 호출 활성화
- 불필요한 refetch 로직 삭제

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
로딩스피너 컴포넌트로 수정했습니다
