### PR TITLE
♻️ Refactor: 내정보 호출 hook 네이밍 수정

### DIFF
--- a/src/api/getMyProfile.ts
+++ b/src/api/getMyProfile.ts
@@ -2,7 +2,7 @@ import { UserProfile } from '../types/User';
 import { formatPhoneNumber } from '../utils/formatPhoneNumber';
 import axiosInstance from './axiosInstance';
 
-const fetchUserProfile = async (): Promise<UserProfile> => {
+const getMyProfile = async (): Promise<UserProfile> => {
   const response = await axiosInstance.get('/api/v1/users/me');
 
   const userId = localStorage.getItem('userId');
@@ -19,4 +19,4 @@ const fetchUserProfile = async (): Promise<UserProfile> => {
   return processedData;
 };
 
-export default fetchUserProfile;
+export default getMyProfile;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,12 +3,12 @@ import { FaBell } from 'react-icons/fa6';
 import { Link, useNavigate } from 'react-router-dom';
 import axiosInstance from '../../api/axiosInstance';
 import logo from '../../assets/svg/logo.svg';
-import useFetchUserProfile from '../../hooks/useFetchUserProfile';
+import useMyProfile from '../../hooks/useMyProfile';
 import useNotifications from '../../hooks/useNotifications';
 import LoadingSpinner from '../LoadingSpinner';
 
 const Header = () => {
-  const { data: userProfileData } = useFetchUserProfile();
+  const { data: userProfileData } = useMyProfile();
   const profileImageUrl = userProfileData?.profileImage;
   const navigate = useNavigate();
   const accessToken = localStorage.getItem('accessToken');

--- a/src/components/MyPage/MyProfile.tsx
+++ b/src/components/MyPage/MyProfile.tsx
@@ -1,6 +1,8 @@
+import { AxiosError } from 'axios';
 import { useCallback, useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import useFetchUserProfile from '../../hooks/useFetchUserProfile';
+import useEditProfile from '../../hooks/useEditProfile';
+import useMyProfile from '../../hooks/useMyProfile';
 import {
   isFormInvalidFormState,
   updatedUserDataState,
@@ -9,8 +11,6 @@ import LoadingSpinner from '../LoadingSpinner';
 import ProfileImageUpload from '../ProfileImageUpload';
 import InfoForm from './InfoForm';
 import ProfileRedirect from './ProfileRedirect';
-import useEditProfile from '../../hooks/useEditProfile';
-import { AxiosError } from 'axios';
 
 const MyProfile = () => {
   const {
@@ -19,7 +19,7 @@ const MyProfile = () => {
     isError: fetchProfileDataIsError,
     refetch,
     error,
-  } = useFetchUserProfile();
+  } = useMyProfile();
 
   // 프로필 검증
   if (error && error instanceof AxiosError) {
@@ -51,16 +51,19 @@ const MyProfile = () => {
   }, [hasProfile, error]);
 
   // 프로필 이미지 변경 이벤트 핸들러
-  const handleProfileImageChange = useCallback((newImageUrl: string | null) => {
-    setProfileImageURL(newImageUrl);
+  const handleProfileImageChange = useCallback(
+    (newImageUrl: string | null) => {
+      setProfileImageURL(newImageUrl);
 
-    if (newImageUrl) {
-      setUpdatedUserData(prevData => ({
-        ...prevData,
-        profileImageUrl: newImageUrl,
-      }));
-    }
-  }, []);
+      if (newImageUrl) {
+        setUpdatedUserData(prevData => ({
+          ...prevData,
+          profileImageUrl: newImageUrl,
+        }));
+      }
+    },
+    [setUpdatedUserData]
+  );
 
   const { mutate: editProfile, isPending: editProfileIsPending } =
     useEditProfile();

--- a/src/hooks/useEditProfile.ts
+++ b/src/hooks/useEditProfile.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { UpdatedUserProfile } from '../types/User';
 import axiosInstance from '../api/axiosInstance';
+import type { UpdatedUserProfile } from '../types/User';
 
 const useEditProfile = () => {
   const queryClient = useQueryClient();
@@ -18,10 +18,7 @@ const useEditProfile = () => {
   return useMutation({
     mutationFn: editProfile,
     onSuccess: updatedData =>
-      queryClient.setQueryData<UpdatedUserProfile>(
-        ['UserProfile'],
-        updatedData
-      ),
+      queryClient.setQueryData<UpdatedUserProfile>(['my-profile'], updatedData),
     retry: false,
   });
 };

--- a/src/hooks/useMyProfile.ts
+++ b/src/hooks/useMyProfile.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import fetchUserProfile from '../api/fetchUserProfile';
+import getMyProfile from '../api/getMyProfile';
 
-const useFetchUserProfile = () => {
+const useMyProfile = () => {
   const accessToken = localStorage.getItem('accessToken');
 
   return useQuery({
-    queryKey: ['UserProfile'],
-    queryFn: fetchUserProfile,
+    queryKey: ['my-profile'],
+    queryFn: getMyProfile,
     select: data => {
       const profileImage = data.profileImageUrl;
       return { profileImage, allData: data };
@@ -15,4 +15,4 @@ const useFetchUserProfile = () => {
   });
 };
 
-export default useFetchUserProfile;
+export default useMyProfile;


### PR DESCRIPTION
## 📌 관련 이슈
- close #245 

## 📝 변경 사항
### AS-IS
- 내정보 호출 hook의 이름 : `useFetchUserProfile`
- 쿼리 key : "UserProfile"

### TO-BE
- 내정보 호출 hook의 이름 : `useMyProfile`
- 쿼리 key : "my-profile"

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [ ] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
