### PR TITLE
♻️ Refactor: useEditProfile 리팩토링

### DIFF
--- a/src/components/MyPage/MyProfile.tsx
+++ b/src/components/MyPage/MyProfile.tsx
@@ -17,7 +17,6 @@ const MyProfile = () => {
     data: profileData,
     isLoading: fetchProfileDataIsLoading,
     isError: fetchProfileDataIsError,
-    refetch,
     error,
   } = useMyProfile();
 
@@ -83,15 +82,7 @@ const MyProfile = () => {
   const handleSubmit = (e: React.MouseEvent) => {
     e.preventDefault();
 
-    editProfile(formData, {
-      onSuccess: async () => {
-        await refetch();
-      },
-      onError: error => {
-        console.log(error);
-        alert('프로필 수정에 실패하였습니다.');
-      },
-    });
+    editProfile(formData);
 
     setIsModified(false);
     setIsCanceled(false);

--- a/src/hooks/useEditProfile.ts
+++ b/src/hooks/useEditProfile.ts
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axiosInstance from '../api/axiosInstance';
-import type { UpdatedUserProfile } from '../types/User';
 
 const useEditProfile = () => {
   const queryClient = useQueryClient();
@@ -17,9 +16,14 @@ const useEditProfile = () => {
 
   return useMutation({
     mutationFn: editProfile,
-    onSuccess: updatedData =>
-      queryClient.setQueryData<UpdatedUserProfile>(['my-profile'], updatedData),
-    retry: false,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['my-profile'] });
+      alert('프로필이 수정되었습니다.');
+    },
+    onError: error => {
+      console.log(error);
+      alert('프로필 수정에 실패하였습니다.');
+    },
   });
 };
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #247 

## 📝 변경 사항
### AS-IS
- mutation의 데이터 업데이트 로직이 hook마다 상이
- onSuccess 콜백이 hook과 컴포넌트에 따로 존재

### TO-BE
- queryClient.invalidateQueries 를 사용해서 데이터를 업데이트하도록 수정
- onSuccess, onError 콜백을 hook에서 관리하도록 수정
- 불필요한 refetch 로직, retry 설정 삭제
- 프로필 성공 알림창 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/028a559e-60d9-4376-ab9a-183f4b59e197)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
