### PR TITLE
🐛 [fix] 모집 취소 API 호출 성공시 리다이렉트 수정

### DIFF
--- a/src/hooks/useDeleteMeeting.ts
+++ b/src/hooks/useDeleteMeeting.ts
@@ -11,7 +11,7 @@ const useDeleteMeeting = () => {
     mutationFn: (id: string) => deleteMeeting(id),
     onSuccess: () => {
       alert('모임이 취소되었습니다.');
-      if (location.pathname === '/view-applicant')
+      if (location.pathname.startsWith('/view-applicant'))
         navigate('/mypage/my-meetings', { replace: true });
       else queryClient.invalidateQueries({ queryKey: ['get-my-meetings'] });
     },


### PR DESCRIPTION
## 📌 관련 이슈
- close #256 

## 📝 변경 사항
### AS-IS
- 모집 취소 API 호출 성공 이벤트의 조건으로 설정된 path가 일치하지 않음

### TO-BE
- startWith를 사용해서 조건이 제대로 작동하도록 수정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
