### PR TITLE
♻️ [Refactor] 모임 상태 변경 API -> 모집 완료 API로 변경

### DIFF
--- a/src/api/meeting.ts
+++ b/src/api/meeting.ts
@@ -1,7 +1,6 @@
 import type {
   CreateMeetingResponse,
   getMyMeetingsRequest,
-  MeetingStatus,
   SearchMeetingsRequest,
 } from '../types/Meeting';
 import { apiClient } from './apiClient';
@@ -29,8 +28,8 @@ export const deleteMeeting = async (id: string) =>
 export const searchMeetings = async (params: SearchMeetingsRequest) =>
   apiClient({ url: COMMON_URL, method: 'get', params });
 
-export const setMeetingStatus = async (id: string, data: MeetingStatus) =>
-  apiClient({ url: `${COMMON_URL}/${id}`, method: 'patch', data });
+export const completeMeeting = async (id: string) =>
+  apiClient({ url: `${COMMON_URL}/${id}/complete`, method: 'patch' });
 
 export const getParticipants = async (id: number) =>
   apiClient({ url: `${COMMON_URL}/${id}/participants`, method: 'get' });

--- a/src/components/PostCardBtn.tsx
+++ b/src/components/PostCardBtn.tsx
@@ -33,11 +33,8 @@ const PostCardBtn: React.FC<PostCardBtnProps> = ({
     // TODO: API 참가한 모임 목록에서 DELETE 요청(신청자 입장)
   };
 
-  const isAvailableDelete =
-    status === '승인 거부' || status === '모집 취소' || status === '모집 완료';
-
   const isAvailableViewPost = status === 'RECRUITING';
-  const isAbailableDelete = status === 'CLOSED';
+  const isAvailableDelete = status === 'CLOSED';
 
   return (
     <>
@@ -56,7 +53,7 @@ const PostCardBtn: React.FC<PostCardBtnProps> = ({
           ) : (
             <div className="flex-1" />
           )}
-          {isAbailableDelete ? (
+          {isAvailableDelete ? (
             <button
               type="button"
               onClick={() => handleDeleteMeetingBtnClick()}

--- a/src/components/PostCardBtn.tsx
+++ b/src/components/PostCardBtn.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { CreatedMeeting, ParticipantsResponse } from '../types/Meeting';
 import useDeleteMeeting from '../hooks/useDeleteMeeting';
+import useDeleteParticipation from '../hooks/useDeleteParticipation';
 
 interface PostCardBtnProps {
   post: CreatedMeeting | ParticipantsResponse;
@@ -16,6 +17,7 @@ const PostCardBtn: React.FC<PostCardBtnProps> = ({
 }) => {
   const navigate = useNavigate();
   const { mutate: deleteMeeting } = useDeleteMeeting();
+  const { mutate: deleteParticipation } = useDeleteParticipation();
 
   const handleGoToPostBtnClick = () => {
     navigate(`/post/${post.meetingId}`);
@@ -30,11 +32,13 @@ const PostCardBtn: React.FC<PostCardBtnProps> = ({
   };
 
   const handleDeleteBtnClick = () => {
-    // TODO: API 참가한 모임 목록에서 DELETE 요청(신청자 입장)
+    if ('participationId' in post) {
+      deleteParticipation(post.participationId);
+    }
   };
 
   const isAvailableViewPost = status === 'RECRUITING';
-  const isAvailableDelete = status === 'CLOSED';
+  const isAvailableDelete = status === 'CLOSED' || status === 'REJECTED';
 
   return (
     <>

--- a/src/hooks/useCloseMeeting.ts
+++ b/src/hooks/useCloseMeeting.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { setMeetingStatus } from '../api/meeting';
+import { completeMeeting } from '../api/meeting';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 
@@ -7,7 +7,7 @@ export function useCloseMeeting() {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: async (id: string) => {
-      await setMeetingStatus(id, { meetingStatus: 'CLOSED' });
+      await completeMeeting(id);
     },
     onSuccess: () => {
       alert('모집완료 되었습니다.');

--- a/src/hooks/useDeleteMeeting.ts
+++ b/src/hooks/useDeleteMeeting.ts
@@ -11,7 +11,7 @@ const useDeleteMeeting = () => {
     mutationFn: (id: string) => deleteMeeting(id),
     onSuccess: () => {
       alert('모임이 취소되었습니다.');
-      if (location.pathname === '/view-applicant')
+      if (location.pathname.startsWith('/view-applicant'))
         navigate('/mypage/my-meetings', { replace: true });
       else queryClient.invalidateQueries({ queryKey: ['get-my-meetings'] });
     },

--- a/src/hooks/useDeleteParticipation.ts
+++ b/src/hooks/useDeleteParticipation.ts
@@ -1,12 +1,16 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { deleteParticipation } from '../api/paricipations';
 
-const useDeleteParticipation = (id: number) => {
+const useDeleteParticipation = () => {
+  const queryclient = useQueryClient();
   return useMutation({
-    mutationFn: () => deleteParticipation(id),
+    mutationFn: (id: number) => deleteParticipation(id),
     onSuccess: () => {
       alert('신청이 취소되었습니다.');
+      queryclient.invalidateQueries({
+        queryKey: ['get-participated-meetings'],
+      });
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/pages/ApplyMeetingPage.tsx
+++ b/src/pages/ApplyMeetingPage.tsx
@@ -13,7 +13,7 @@ const ApplyMeetingPage = ({ meeting }: { meeting: Post }) => {
     !!appliedMeetingIds?.includes(meeting.id)
   );
 
-  let participatingId;
+  let participatingId = 0;
   if (participatingIds && appliedMeetingIds) {
     participatingId = participatingIds[appliedMeetingIds.indexOf(meeting.id)];
   }
@@ -23,10 +23,10 @@ const ApplyMeetingPage = ({ meeting }: { meeting: Post }) => {
   const {
     mutate: cancelParticipation,
     isSuccess: cancelParticipationIsSuccess,
-  } = useDeleteParticipation(Number(participatingId));
+  } = useDeleteParticipation();
 
   const handleCancelParticipation = () => {
-    cancelParticipation();
+    cancelParticipation(participatingId);
   };
 
   const handleParticipate = () => {

--- a/src/types/Meeting.ts
+++ b/src/types/Meeting.ts
@@ -35,10 +35,6 @@ export interface SearchMeetingsRequest {
   pageSize?: number;
 }
 
-export interface MeetingStatus {
-  meetingStatus: 'RECRUITING' | 'CLOSED';
-}
-
 export interface getMyMeetingsRequest {
   lastId?: number;
   pageSize?: number;


### PR DESCRIPTION
## 📌 관련 이슈
- close #260 

## 📝 변경 사항
### AS-IS
- 모집 상태 변경("모집중", "모집 완료")이 가능
- 참여한 모임 목록에서 승인 대기 중인 회원의 경우 모집 완료 상태가 반환이 되지 않고 계속 승인 대기 상태를 반환함

### TO-BE
- "모집중" 상태 변경을 할 필요가 없으므로 모집 완료 API로 변경
- 참여한 모임 목록에서 승인 대기 중인 회원도 모집 완료 상태가 반환되어 삭제 버튼을 활성화 시킬 수 있도록 수정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
승인 대기 중 모집 완료된 회원의 카드
<img width="358" alt="스크린샷 2025-02-14 오전 12 11 21" src="https://github.com/user-attachments/assets/25eea6fa-15dc-48ea-b0fe-e9d3e777a27b" />

승인 완료된 회원의 카드(승인 완료 -> 모임 참여 = 채팅 참여)
<img width="394" alt="스크린샷 2025-02-14 오전 12 12 42" src="https://github.com/user-attachments/assets/24fe8a55-266f-4ce5-b3db-de8792a802dd" />
<img width="398" alt="스크린샷 2025-02-14 오전 12 12 46" src="https://github.com/user-attachments/assets/d9ce5129-5ab9-4a27-bacf-0bea202045fc" />




## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
