### PR TITLE
♻️ [Refactor] 카카오 유저 닉네임 기본값 수정

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -6,15 +6,17 @@ interface RequestConfig {
   method?: Method | string;
   data?: any;
   params?: any;
+  headers?: any;
 }
 
 export async function apiClient<T = any>(config: RequestConfig): Promise<T> {
-  const { url, method = 'get', data, params } = config;
+  const { url, method = 'get', data, params, headers } = config;
   const response = await axiosInstance({
     url,
     method,
     data,
     params,
+    headers,
   });
   return response.data;
 }

--- a/src/api/getMyProfile.ts
+++ b/src/api/getMyProfile.ts
@@ -5,15 +5,11 @@ import axiosInstance from './axiosInstance';
 const getMyProfile = async (): Promise<UserProfile> => {
   const response = await axiosInstance.get('/api/v1/users/me');
 
-  const userId = localStorage.getItem('userId');
-
   const processedData: UserProfile = {
     ...response.data,
     mbti: response.data.mbti === 'NONE' ? '' : response.data.mbti,
     profileImageUrl: response.data.profileImageUrl || null,
     phone: formatPhoneNumber(response.data.phone),
-    nickname:
-      response.data.nickname === '' ? `anony${userId}` : response.data.nickname,
   };
 
   return processedData;

--- a/src/api/uesrs.ts
+++ b/src/api/uesrs.ts
@@ -1,0 +1,117 @@
+import {
+  changePasswordRequest,
+  EmailLoginRequest,
+  EmailLoginResponse,
+  GetUserProfileResponse,
+  JoinUserRequest,
+} from './../types/User';
+import { MyProfile } from '../types/User';
+import { formatPhoneNumber } from '../utils/formatPhoneNumber';
+import { apiClient } from './apiClient';
+
+const COMMON_URL = '/api/v1/users';
+
+// 회원가입
+export const joinUser = async (form: JoinUserRequest) =>
+  apiClient({
+    url: `${COMMON_URL}/signup`,
+    method: 'post',
+    data: {
+      ...form,
+      phone: form.phoneNumber.replace(/[^0-9]/g, ''),
+    },
+  });
+
+// 이메일 인증
+export const confirmEmailCode = async (code: string) => {
+  return apiClient({
+    url: `${COMMON_URL}/signup/verify`,
+    method: 'post',
+    params: {
+      code: code,
+    },
+  });
+};
+
+// 로그인
+export const emailLogin = async (
+  form: EmailLoginRequest
+): Promise<EmailLoginResponse> => {
+  return apiClient<EmailLoginResponse>({
+    url: `${COMMON_URL}/login`,
+    method: 'post',
+    data: form,
+  });
+};
+
+// 로그아웃
+export const logout = async () =>
+  apiClient({
+    url: `${COMMON_URL}/logout`,
+    method: 'delete',
+  });
+
+// 회원탈퇴
+export const deleteAccount = async () =>
+  apiClient({
+    url: `${COMMON_URL}`,
+    method: 'delete',
+  });
+
+// 이메일로 재설정 링크 발송
+export const sendLinkToEmail = async (email: string) => {
+  return apiClient({
+    url: `${COMMON_URL}/password/change/link-send`,
+    method: 'post',
+    data: {
+      email: email,
+    },
+  });
+};
+
+// 비밀번호 변경
+export const changePassword = async (
+  form: changePasswordRequest
+): Promise<changePasswordRequest> => {
+  return apiClient<changePasswordRequest>({
+    url: `${COMMON_URL}/password/change`,
+    method: 'post',
+    data: form,
+  });
+};
+
+// 본인 프로필 조회
+export const getMyProfile = async (): Promise<MyProfile> => {
+  const data = await apiClient<MyProfile>({
+    url: `${COMMON_URL}/me`,
+    method: 'get',
+  });
+
+  return {
+    ...data,
+    mbti: data.mbti === 'NONE' ? '' : data.mbti,
+    profileImageUrl: data.profileImageUrl,
+    phone: formatPhoneNumber(data.phone ?? ''),
+  };
+};
+
+// 타인 프로필 조회
+export const getUserProfile = async (
+  userId: number
+): Promise<GetUserProfileResponse> => {
+  return await apiClient<GetUserProfileResponse>({
+    url: `${COMMON_URL}/${userId}`,
+    method: 'get',
+  });
+};
+
+// 프로필 수정
+export const editProfile = async (profileData: FormData) =>
+  apiClient({
+    url: `${COMMON_URL}/me`,
+    method: 'put',
+    data: profileData,
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });

--- a/src/components/Chat/ChatParticipantList.tsx
+++ b/src/components/Chat/ChatParticipantList.tsx
@@ -60,9 +60,7 @@ const ChatParticipantList = ({
                   alt="participant profile image"
                   className="w-10 h-10 rounded-full border-[1px] border-black bg-white p-[1px] mr-2"
                 />
-                <span className="font-bold">
-                  {participant.nickname || `anony${participant.id}`}
-                </span>
+                <span className="font-bold">{participant.nickname}</span>
               </li>
             </Link>
           ))}

--- a/src/components/Chat/ChatRoom.tsx
+++ b/src/components/Chat/ChatRoom.tsx
@@ -48,7 +48,7 @@ const ChatRoom: React.FC<ChatRoomProps> = ({
               roomId: chat.roomId,
               message,
               senderId: userId.toString(),
-              senderNickname: senderNickname || `anony${userId}`,
+              senderNickname: senderNickname,
               userProfileImageUrl,
             })
           )
@@ -79,8 +79,7 @@ const ChatRoom: React.FC<ChatRoomProps> = ({
               {
                 ...msg,
                 senderId: msg.senderId.toString(),
-                senderNickname: msg.senderNickname || `anony${msg.senderId}`,
-                // userProfileImageUrl: msg.userProfileImageUrl,
+                senderNickname: msg.senderNickname,
               },
             ]);
             console.log(msg);

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,13 +1,13 @@
 import { useMutation } from '@tanstack/react-query';
 import { FaBell } from 'react-icons/fa6';
 import { Link, useNavigate } from 'react-router-dom';
-import axiosInstance from '../../api/axiosInstance';
 import logo from '../../assets/svg/logo.svg';
 import useMyProfile from '../../hooks/useMyProfile';
 import useNotifications from '../../hooks/useNotifications';
 import LoadingSpinner from '../LoadingSpinner';
 import { AxiosError } from 'axios';
 import ProfileRedirectModal from '../MyPage/ProfileRedirectModal';
+import { logout } from '../../api/uesrs';
 
 const Header = () => {
   const { data: userProfileData, error } = useMyProfile();
@@ -19,11 +19,8 @@ const Header = () => {
     navigate('/mypage/my-profile');
   };
 
-  const { mutate: logout, isPending: isLogoutPending } = useMutation({
-    mutationFn: async () => {
-      const response = await axiosInstance.delete('/api/v1/users/logout');
-      return response.data;
-    },
+  const { mutate: handleLogout, isPending: isLogoutPending } = useMutation({
+    mutationFn: logout,
     onSuccess: data => {
       localStorage.removeItem('accessToken');
       localStorage.removeItem('loginType');
@@ -124,7 +121,10 @@ const Header = () => {
               >
                 <a className="text-sm hover:font-bold">마이페이지</a>
               </li>
-              <li className="w-full items-center" onClick={() => logout()}>
+              <li
+                className="w-full items-center"
+                onClick={() => handleLogout()}
+              >
                 <a className="text-sm hover:font-bold flex justify-center w-full">
                   로그아웃
                 </a>

--- a/src/components/Join/JoinForm.tsx
+++ b/src/components/Join/JoinForm.tsx
@@ -12,8 +12,8 @@ import {
 } from './validation';
 import { JoinErrorMessages } from '../../types/Errors.ts';
 import { formatPhoneNumber } from '../../utils/formatPhoneNumber.ts';
-import axiosInstance from '../../api/axiosInstance.ts';
 import { useMutation } from '@tanstack/react-query';
+import { joinUser } from '../../api/uesrs.ts';
 
 type Form = {
   email: string;
@@ -44,7 +44,6 @@ const JoinForm = () => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-
     setForm(prev => ({
       ...prev,
       [name]: name === 'phoneNumber' ? formatPhoneNumber(value) : value,
@@ -74,16 +73,6 @@ const JoinForm = () => {
     });
   };
 
-  const joinUser = async () => {
-    const response = await axiosInstance.post('/api/v1/users/signup', {
-      email: form.email,
-      password: form.password,
-      nickname: form.nickname,
-      phone: form.phoneNumber.replace(/[^0-9]/g, ''),
-    });
-    return response.data;
-  };
-
   const navigate = useNavigate();
 
   const { mutate, isPending } = useMutation({
@@ -111,7 +100,9 @@ const JoinForm = () => {
     e.preventDefault();
     clearErrors();
     setValidationErrors();
-    mutate();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { passwordConfirm, ...submitForm } = form;
+    mutate(submitForm);
   };
 
   const isFormValid =

--- a/src/components/Join/RedirectResetPassword.tsx
+++ b/src/components/Join/RedirectResetPassword.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
-import axiosInstance from '../../api/axiosInstance';
 import JoinField from './JoinField';
 import {
   handleValidation,
@@ -9,6 +8,8 @@ import {
   validatePasswordConfirm,
 } from './validation';
 import { passwordErrorMessages } from '../../types/Errors';
+import { useMutation } from '@tanstack/react-query';
+import { changePassword } from '../../api/uesrs';
 
 const RedirectResetPassword = () => {
   const navigate = useNavigate();
@@ -28,22 +29,19 @@ const RedirectResetPassword = () => {
 
   const token = new URL(window.location.href).searchParams.get('token');
 
-  const fetchAccessToken = async () => {
-    try {
-      await axiosInstance.post('/api/v1/users/password/change', {
-        token: token,
-        newPassword: password,
-      });
-
+  const { mutate } = useMutation({
+    mutationFn: changePassword,
+    onSuccess: () => {
       alert('비밀번호가 변경되었습니다. 다시 로그인해주세요.');
       setValidationErrors();
       navigate('/login');
-    } catch (err) {
+    },
+    onError: err => {
       if (err instanceof AxiosError) {
         console.log(err.message);
       }
-    }
-  };
+    },
+  });
 
   return (
     <div className="w-full h-screen flex justify-center items-center">
@@ -91,7 +89,12 @@ const RedirectResetPassword = () => {
           />
           <button
             type="button"
-            onClick={fetchAccessToken}
+            onClick={() =>
+              mutate({
+                token: token || '',
+                newPassword: password,
+              })
+            }
             disabled={!password || !passwordConfirm}
             className="btn btn-block font-bold text-[16px] btn-primary border-none"
           >

--- a/src/components/Join/ResetPassword.tsx
+++ b/src/components/Join/ResetPassword.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import Input from '../Input';
-import axiosInstance from '../../api/axiosInstance';
 import { AxiosError } from 'axios';
 import { useMutation } from '@tanstack/react-query';
+import { sendLinkToEmail } from '../../api/uesrs';
 
 const ResetPassword = () => {
   const [email, setEmail] = useState<string>('');
@@ -10,15 +10,7 @@ const ResetPassword = () => {
   const [success, setSuccess] = useState<string | null>(null);
 
   const { mutate, isPending } = useMutation({
-    mutationFn: async () => {
-      const response = await axiosInstance.post(
-        '/api/v1/users/password/change/link-send',
-        {
-          email: email,
-        }
-      );
-      return response.data;
-    },
+    mutationFn: sendLinkToEmail,
     onSuccess: () => {
       setError(null);
       setSuccess(
@@ -38,7 +30,7 @@ const ResetPassword = () => {
 
   const handleResetPassword = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    mutate();
+    mutate(email);
   };
 
   const handleConfirmBtn = () => {

--- a/src/components/Join/VerifyEmailCode.tsx
+++ b/src/components/Join/VerifyEmailCode.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { AxiosError } from 'axios';
 import { Link } from 'react-router-dom';
 import JoinField from './JoinField';
-import axiosInstance from '../../api/axiosInstance';
 import { useMutation } from '@tanstack/react-query';
+import { confirmEmailCode } from '../../api/uesrs';
 
 const VerifyEmailCode = () => {
   const [emailConfirmCode, setEmailConfirmCode] = useState<string>('');
@@ -11,19 +11,6 @@ const VerifyEmailCode = () => {
     string | null
   >(null);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-
-  const confirmEmailCode = async (code: string) => {
-    const response = await axiosInstance.post(
-      '/api/v1/users/signup/verify',
-      null,
-      {
-        params: {
-          code: code,
-        },
-      }
-    );
-    return response.data;
-  };
 
   const { mutate, isPending } = useMutation({
     mutationFn: confirmEmailCode,

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -3,29 +3,22 @@ import { RiKakaoTalkFill } from 'react-icons/ri';
 import Input from '../Input';
 import { AxiosError } from 'axios';
 import { useState } from 'react';
-import axiosInstance from '../../api/axiosInstance';
 import { useMutation } from '@tanstack/react-query';
 import LoadingSpinner from '../LoadingSpinner';
+import { emailLogin } from '../../api/uesrs';
 
 const LoginForm = () => {
-  const [email, setEmail] = useState<string>('');
-  const [password, setPassword] = useState<string>('');
+  const [formData, setFormData] = useState({ email: '', password: '' });
   const [loginError, setLoginError] = useState<string | null>(null);
 
   const navigate = useNavigate();
 
   const { mutate, isPending } = useMutation({
-    mutationFn: async () => {
-      const response = await axiosInstance.post('/api/v1/users/login', {
-        email: email,
-        password: password,
-      });
-      return response.data;
-    },
+    mutationFn: () => emailLogin(formData),
     onSuccess: data => {
       if (data && data.accessToken) {
         localStorage.setItem('accessToken', data.accessToken);
-        localStorage.setItem('userId', data.userId);
+        localStorage.setItem('userId', data.userId.toString());
       }
 
       localStorage.setItem('loginType', 'email');
@@ -58,6 +51,14 @@ const LoginForm = () => {
     window.location.href = kakaoLoginUrl;
   };
 
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prevState => ({
+      ...prevState,
+      [name]: value,
+    }));
+  };
+
   if (isPending) {
     return (
       <div className="w-full h-screen flex justify-center items-center">
@@ -76,16 +77,16 @@ const LoginForm = () => {
         <Input
           type="email"
           name="email"
-          value={email}
-          onChange={e => setEmail(e.target.value)}
+          value={formData.email}
+          onChange={handleChange}
           placeholder="이메일을 입력해주세요."
           required
         />
         <Input
           type="password"
           name="password"
-          value={password}
-          onChange={e => setPassword(e.target.value)}
+          value={formData.password}
+          onChange={handleChange}
           placeholder="비밀번호를 입력해주세요."
           required
         />

--- a/src/components/MyPage/AccountDeletion.tsx
+++ b/src/components/MyPage/AccountDeletion.tsx
@@ -2,13 +2,9 @@ import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import axiosInstance from '../../api/axiosInstance';
 import LoadingSpinner from '../LoadingSpinner';
+import { deleteAccount } from '../../api/uesrs';
 
-const deleteAccount = async () => {
-  const response = await axiosInstance.delete('/api/v1/users');
-  return response.data;
-};
 const AccountDeletion = () => {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const navigate = useNavigate();

--- a/src/components/MyPage/HostedMeetings.tsx
+++ b/src/components/MyPage/HostedMeetings.tsx
@@ -1,7 +1,7 @@
 import { useRecoilValue } from 'recoil';
-import useGetMyMeetings from '../../hooks/useGetmyMeetings';
 import { isActiveState } from '../../states/recoilState';
 import PostCard from '../PostCard';
+import useGetMyMeetings from '../../hooks/useGetmyMeetings';
 
 const HostedMeetings = () => {
   const { data } = useGetMyMeetings({});

--- a/src/components/MyPage/ParticipantList.tsx
+++ b/src/components/MyPage/ParticipantList.tsx
@@ -55,9 +55,7 @@ const ParticipantList = ({
                 alt={participant.nickname}
                 className="w-10 h-10 rounded-full p-[1px] bg-white border-gray-600 border-[1px]"
               />
-              <span className="font-bold text-sm">
-                {participant.nickname || `anony${participant.userId}`}
-              </span>
+              <span className="font-bold text-sm">{participant.nickname}</span>
             </li>
           ))
         ) : (

--- a/src/hooks/useDeleteMeeting.ts
+++ b/src/hooks/useDeleteMeeting.ts
@@ -1,15 +1,26 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { deleteMeeting } from '../api/meeting';
+import { useLocation } from 'react-router-dom';
 
 interface UseDeleteMeetingProps {
   onSuccess: () => void;
 }
 const useDeleteMeeting = ({ onSuccess }: UseDeleteMeetingProps) => {
+  const locate = useLocation();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => deleteMeeting(id),
     onSuccess: () => {
       onSuccess();
+
+      // 페이지 단위로 모임 리스트 업데이트
+      if (locate.pathname === '/') {
+        queryClient.invalidateQueries({ queryKey: ['search-meetings'] });
+      }
+      if (locate.pathname === '/mypage/my-meetings') {
+        queryClient.invalidateQueries({ queryKey: ['my-meetings'] });
+      }
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/hooks/useEditProfile.ts
+++ b/src/hooks/useEditProfile.ts
@@ -1,18 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import axiosInstance from '../api/axiosInstance';
+import { editProfile } from '../api/uesrs';
 
 const useEditProfile = () => {
   const queryClient = useQueryClient();
-
-  const editProfile = async (profileData: FormData) => {
-    const response = await axiosInstance.put('/api/v1/users/me', profileData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
-
-    return response.data;
-  };
 
   return useMutation({
     mutationFn: editProfile,

--- a/src/hooks/useGetUserProfile.ts
+++ b/src/hooks/useGetUserProfile.ts
@@ -1,14 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import axiosInstance from '../api/axiosInstance';
-import { getUserProfileResponse } from '../types/User';
-
-const getUserProfile = async (userId: number) => {
-  const response = await axiosInstance.get(`/api/v1/users/${userId}`);
-  return response.data;
-};
+import { GetUserProfileResponse } from '../types/User';
+import { getUserProfile } from '../api/uesrs';
 
 export function useGetUserProfile(userId: number) {
-  return useQuery<getUserProfileResponse>({
+  return useQuery<GetUserProfileResponse>({
     queryKey: ['userProfile', userId],
     queryFn: () => getUserProfile(userId),
   });

--- a/src/hooks/useGetmyMeetings.ts
+++ b/src/hooks/useGetmyMeetings.ts
@@ -7,7 +7,7 @@ interface GetMyMeetingsResponse {
 }
 const useGetMyMeetings = (params: getMyMeetingsRequest) => {
   return useQuery<GetMyMeetingsResponse>({
-    queryKey: ['get-my-meetings', params],
+    queryKey: ['my-meetings', params],
     queryFn: () => getMyMeetings(params),
     refetchOnWindowFocus: false,
     retry: false,

--- a/src/hooks/useMyProfile.ts
+++ b/src/hooks/useMyProfile.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import getMyProfile from '../api/getMyProfile';
+import { getMyProfile } from '../api/uesrs';
 
 const useMyProfile = () => {
   const accessToken = localStorage.getItem('accessToken');

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -43,11 +43,7 @@ const UserProfilePage = () => {
                 type="text"
                 disabled
                 required
-                placeholder={
-                  userProfile.nickname === ''
-                    ? `anony${userId}`
-                    : userProfile.nickname
-                }
+                placeholder={userProfile.nickname}
               />
               <InfoFormField
                 name="age"

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -12,7 +12,7 @@ export interface User {
   status: string;
 }
 
-export interface UserProfile {
+export interface MyProfile {
   birth: string;
   email: string;
   gender: string;
@@ -40,7 +40,7 @@ export interface Participants {
   participationStatus: string;
 }
 
-export interface getUserProfileResponse {
+export interface GetUserProfileResponse {
   userId: number;
   nickname: string;
   gender: string;
@@ -48,4 +48,26 @@ export interface getUserProfileResponse {
   profileImageUrl: string;
   introduction: string;
   mbti: string;
+}
+
+export interface JoinUserRequest {
+  email: string;
+  password: string;
+  nickname: string;
+  phoneNumber: string;
+}
+
+export interface EmailLoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface EmailLoginResponse {
+  accessToken: string;
+  userId: number;
+}
+
+export interface changePasswordRequest {
+  token: string;
+  newPassword: string;
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #273 

## 📝 변경 사항
### AS-IS
- 카카오 유저는 기본 닉네임이 없으므로 프론트단에서 기본값을 설정해 보여줌 

### TO-BE
- 알림 메세지 등 서버에서 넘어오는 데이터자체에서 닉네임 필드값이 필요한 경우가 있기 때문에 카카오 유저의 경우 백에서 기본값을 설정하고 프론트에 그 값을 내려주는 것으로 변경
- 불필요한 기본값 설정 코드를 제거

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
