### PR TITLE
♻️ [Refactor] 채팅 모달에서 채팅 삭제 후 모임 리스트 업데이트 개선

### DIFF
--- a/src/components/MyPage/HostedMeetings.tsx
+++ b/src/components/MyPage/HostedMeetings.tsx
@@ -1,7 +1,7 @@
 import { useRecoilValue } from 'recoil';
-import useGetMyMeetings from '../../hooks/useGetmyMeetings';
 import { isActiveState } from '../../states/recoilState';
 import PostCard from '../PostCard';
+import useGetMyMeetings from '../../hooks/useGetmyMeetings';
 
 const HostedMeetings = () => {
   const { data } = useGetMyMeetings({});

--- a/src/hooks/useDeleteMeeting.ts
+++ b/src/hooks/useDeleteMeeting.ts
@@ -1,15 +1,26 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { deleteMeeting } from '../api/meeting';
+import { useLocation } from 'react-router-dom';
 
 interface UseDeleteMeetingProps {
   onSuccess: () => void;
 }
 const useDeleteMeeting = ({ onSuccess }: UseDeleteMeetingProps) => {
+  const locate = useLocation();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => deleteMeeting(id),
     onSuccess: () => {
       onSuccess();
+
+      // 페이지 단위로 모임 리스트 업데이트
+      if (locate.pathname === '/') {
+        queryClient.invalidateQueries({ queryKey: ['search-meetings'] });
+      }
+      if (locate.pathname === '/mypage/my-meetings') {
+        queryClient.invalidateQueries({ queryKey: ['my-meetings'] });
+      }
     },
     onError: error => {
       if (axios.isAxiosError(error)) {

--- a/src/hooks/useGetmyMeetings.ts
+++ b/src/hooks/useGetmyMeetings.ts
@@ -7,7 +7,7 @@ interface GetMyMeetingsResponse {
 }
 const useGetMyMeetings = (params: getMyMeetingsRequest) => {
   return useQuery<GetMyMeetingsResponse>({
-    queryKey: ['get-my-meetings', params],
+    queryKey: ['my-meetings', params],
     queryFn: () => getMyMeetings(params),
     refetchOnWindowFocus: false,
     retry: false,


### PR DESCRIPTION
## 📌 관련 이슈
- close #277 

## 📝 변경 사항
### AS-IS
- 채팅 모달에서 모임이 삭제되어도 뒷 화면에 모임 리스트가 업데이트 되지 않음

### TO-BE
- 채팅 모달이 활성화 된 페이지 단위로 (업데이트가 필요한 페이지라면) 모임 리스트가 업데이트 되도록 개선

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항
